### PR TITLE
Migrate from PHPUnit 9 to PHPUnit 10

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,19 +12,24 @@ jobs:
         include:
           - php: 8.0
             buildphar: false
+            runtests: false
             experimental: false
           - php: 8.1
             buildphar: false
+            runtests: true
             experimental: false
           - php: 8.2
             buildphar: true
+            runtests: true
             experimental: false
           - php: 8.3
             buildphar: true
+            runtests: true
             experimental: false
           - php: 8.4
             buildphar: true
-            experimental: true
+            runtests: false
+            experimental: false
     env:
       PHAR: build/phar/captainhook.phar
 
@@ -54,12 +59,15 @@ jobs:
       run: GITHUB_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }} tools/phive --no-progress --home ./.phive install --force-accept-unsigned --trust-gpg-keys 4AA394086372C20A,31C7E470E2138192,8E730BA25823D8B5,CF1A108D0E7AE720,2DF45277AEF09A2F,51C67305FFC2E5C0
 
     - name: Execute unit tests
+      if: ${{ matrix.runtests }}
       run: tools/phpunit --no-coverage --testsuite UnitTests
 
     - name: Execute integration tests
+      if: ${{ matrix.runtests }}
       run: tools/phpunit --no-coverage --testsuite IntegrationTests
 
     - name: Execute end-to-end tests
+      if: ${{ matrix.runtests }}
       run: tools/phpunit --no-coverage --testsuite EndToEndTests
 
     - name: Execute dummy pre commit

--- a/phive.xml
+++ b/phive.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpunit" version="^9.4" installed="9.6.23" location="./tools/phpunit" copy="true"/>
-  <phar name="humbug/box" version="^4.0" installed="4.6.6" location="./tools/box" copy="true"/>
+  <phar name="phpunit" version="^10.0" installed="10.5.58" location="./tools/phpunit" copy="true"/>
+  <phar name="humbug/box" version="^4.0" installed="4.6.8" location="./tools/box" copy="true"/>
   <phar name="phpcs" version="^3.5" installed="3.7.2" location="./tools/phpcs" copy="true"/>
-  <phar name="phpstan" version="^1.0" installed="1.12.28" location="./tools/phpstan" copy="true"/>
+  <phar name="phpstan" version="^1.0" installed="1.12.32" location="./tools/phpstan" copy="true"/>
 </phive>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          colors="true"
          bootstrap="tests/bootstrap.php"
-         defaultTestSuite="UnitTests">
+         defaultTestSuite="UnitTests"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerWarnings="true">
   <coverage>
-    <include>
-      <directory>src</directory>
-    </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
       <html outputDirectory="build/coverage" lowUpperBound="35" highLowerBound="70"/>
@@ -27,4 +26,9 @@
   <logging>
     <junit outputFile="build/logs/junit.xml"/>
   </logging>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Config/Factory.php
+++ b/src/Config/Factory.php
@@ -138,9 +138,12 @@ final class Factory
 
         $this->appendIncludedConfigurations($config, $json);
 
+        // fallback to $json->HOOK_NAME if $json->HOOKS->HOOK_NAME does not exist
+        $hooks = $json['hooks'] ?? $json;
+
         foreach (HookUtil::getValidHooks() as $hook => $class) {
-            if (isset($json[$hook])) {
-                $this->configureHook($config->getHookConfig($hook), $json[$hook]);
+            if (isset($hooks[$hook])) {
+                $this->configureHook($config->getHookConfig($hook), $hooks[$hook]);
             }
         }
 

--- a/tests/_files/bootstrap/crash.php
+++ b/tests/_files/bootstrap/crash.php
@@ -1,3 +1,4 @@
 <?php
 
-require 'foo.txt';
+// I know ugly but I want this to crash
+@require 'foo.txt';

--- a/tests/unit/Config/ConditionTest.php
+++ b/tests/unit/Config/ConditionTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class ConditionTest extends TestCase
 {
-    /**
-     * Tests Condition::getExec
-     */
     public function testGetExec(): void
     {
         $config = new Condition('\\Foo\\Bar');
@@ -25,9 +22,6 @@ class ConditionTest extends TestCase
         $this->assertEquals('\\Foo\\Bar', $config->getExec());
     }
 
-    /**
-     * Tests Condition::getArgs
-     */
     public function testGetEmptyArgs(): void
     {
         $config = new Condition('\\Foo\\Bar');

--- a/tests/unit/Config/FactoryTest.php
+++ b/tests/unit/Config/FactoryTest.php
@@ -16,11 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase
 {
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreate(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/valid.json'));
@@ -29,11 +24,6 @@ class FactoryTest extends TestCase
         $this->assertCount(1, $config->getHookConfig('pre-commit')->getActions());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testOverwriteConfigSettingsBySettingsConfigFile(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/config-file/captainhook.json'));
@@ -41,11 +31,6 @@ class FactoryTest extends TestCase
         $this->assertEquals('quiet', $config->getVerbosity());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithAbsoluteGitDir(): void
     {
         $config = Factory::create(
@@ -58,11 +43,6 @@ class FactoryTest extends TestCase
         $this->assertEquals('/foo', $config->getGitDirectory());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithInvalidPhpPath(): void
     {
         $this->expectException(Exception::class);
@@ -73,11 +53,6 @@ class FactoryTest extends TestCase
         );
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithRelativeGitDir(): void
     {
         $path   = realpath(CH_PATH_FILES . '/config/valid.json');
@@ -88,9 +63,6 @@ class FactoryTest extends TestCase
         $this->assertEquals(dirname($path) . DIRECTORY_SEPARATOR . '../.git', $config->getGitDirectory());
     }
 
-    /**
-     * Tests Factory::create
-     */
     public function testCreateWithRunConfig(): void
     {
         $path   = realpath(CH_PATH_FILES . '/config/valid-run-config-nested.json');
@@ -101,9 +73,6 @@ class FactoryTest extends TestCase
         $this->assertEquals('/docker/.git', $config->getRunConfig()->getGitPath());
     }
 
-    /**
-     * Tests Factory::create
-     */
     public function testCreateWithRunConfigLegacy(): void
     {
         $path   = realpath(CH_PATH_FILES . '/config/valid-run-config-legacy.json');
@@ -114,11 +83,6 @@ class FactoryTest extends TestCase
         $this->assertEquals('/docker/.git', $config->getRunConfig()->getGitPath());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithConditions(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/valid-with-conditions.json'));
@@ -127,11 +91,6 @@ class FactoryTest extends TestCase
         $this->assertCount(1, $config->getHookConfig('pre-commit')->getActions());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithSettings(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/valid-with-conditions.json'));
@@ -139,11 +98,6 @@ class FactoryTest extends TestCase
         $this->assertTrue($config->getHookConfig('pre-commit')->getActions()[0]->isFailureAllowed());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithCrazyPHPPath(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/valid-with-strange-settings.json'));
@@ -151,11 +105,6 @@ class FactoryTest extends TestCase
         $this->assertEquals("tests/_files/bin/success foo", $config->getPhpPath());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithAllSetting(): void
     {
         $path   = realpath(CH_PATH_FILES . '/config/valid-with-all-settings.json');
@@ -172,11 +121,6 @@ class FactoryTest extends TestCase
         $this->assertEquals(false, $config->failOnFirstError());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithIncludes(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/valid-with-includes.json'));
@@ -185,11 +129,6 @@ class FactoryTest extends TestCase
         $this->assertCount(2, $config->getHookConfig('pre-commit')->getActions());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithValidNestedIncludes(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/valid-with-nested-includes.json'));
@@ -200,11 +139,6 @@ class FactoryTest extends TestCase
         $this->assertCount(2, $config->getHookConfig('pre-push')->getActions());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithInvalidNestedIncludes(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/invalid-with-nested-includes.json'));
@@ -213,22 +147,12 @@ class FactoryTest extends TestCase
         $this->assertCount(2, $config->getHookConfig('pre-commit')->getActions());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithInvalidIncludes(): void
     {
         $this->expectException(Exception::class);
         Factory::create(realpath(CH_PATH_FILES . '/config/valid-with-invalid-includes.json'));
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateEmptyWithIncludes(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/empty-with-includes.json'));
@@ -237,11 +161,6 @@ class FactoryTest extends TestCase
         $this->assertCount(1, $config->getHookConfig('pre-commit')->getActions());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testCreateWithNestedAndConditions(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/valid-with-nested-and-conditions.json'));
@@ -250,11 +169,6 @@ class FactoryTest extends TestCase
         $this->assertCount(1, $config->getHookConfig('pre-commit')->getActions());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testWithMainConfigurationOverridingInclude(): void
     {
         $config = Factory::create(realpath(CH_PATH_FILES . '/config/valid-with-disabled-action.json'));
@@ -262,11 +176,6 @@ class FactoryTest extends TestCase
         $this->assertFalse($config->getHookConfig('pre-commit')->isEnabled());
     }
 
-    /**
-     * Tests Factory::create
-     *
-     * @throws \Exception
-     */
     public function testMaxIncludeLevel(): void
     {
         // one of the included files will not be loaded because of the includes-level value of 2

--- a/tests/unit/Config/HookTest.php
+++ b/tests/unit/Config/HookTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class HookTest extends TestCase
 {
-    /**
-     * Tests Hook::__construct
-     */
     public function testDisabledByDefault(): void
     {
         $hook   = new Hook('pre-commit');
@@ -27,9 +24,6 @@ class HookTest extends TestCase
         $this->assertFalse($config['enabled']);
     }
 
-    /**
-     * Tests Hook::setEnabled
-     */
     public function testSetEnabled(): void
     {
         $hook   = new Hook('pre-commit');
@@ -40,9 +34,6 @@ class HookTest extends TestCase
         $this->assertTrue($config['enabled']);
     }
 
-    /**
-     * Tests Hook::__construct
-     */
     public function testEmptyActions(): void
     {
         $hook   = new Hook('pre-commit');
@@ -52,9 +43,6 @@ class HookTest extends TestCase
         $this->assertCount(0, $config['actions']);
     }
 
-    /**
-     * Tests Hook::addAction
-     */
     public function testAddAction(): void
     {
         $hook   = new Hook('pre-commit');
@@ -65,9 +53,6 @@ class HookTest extends TestCase
         $this->assertCount(1, $config['actions']);
     }
 
-    /**
-     * Tests Hook::addAction
-     */
     public function testAddMultiAction(): void
     {
         $hook   = new Hook('pre-commit');

--- a/tests/unit/Config/OptionsTest.php
+++ b/tests/unit/Config/OptionsTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class OptionsTest extends TestCase
 {
-    /**
-     * Tests Options::get
-     */
     public function testGet(): void
     {
         $options = new Options(['foo' => 'bar']);
@@ -25,9 +22,6 @@ class OptionsTest extends TestCase
         $this->assertEquals('bar', $options->get('foo'));
     }
 
-    /**
-     * Tests Options::getOptions
-     */
     public function testGetAll(): void
     {
         $options = new Options(['foo']);

--- a/tests/unit/Config/UtilTest.php
+++ b/tests/unit/Config/UtilTest.php
@@ -17,9 +17,6 @@ use PHPUnit\Framework\TestCase;
 
 class UtilTest extends TestCase
 {
-    /**
-     * Tests Util::validateJsonConfiguration
-     */
     public function testEnabledMissing(): void
     {
         $this->expectException(Exception::class);
@@ -27,9 +24,6 @@ class UtilTest extends TestCase
         Util::validateJsonConfiguration(['pre-commit' => ['actions' => []]]);
     }
 
-    /**
-     * Tests Util::validateJsonConfiguration
-     */
     public function testActionsMissing(): void
     {
         $this->expectException(Exception::class);
@@ -37,9 +31,6 @@ class UtilTest extends TestCase
         Util::validateJsonConfiguration(['pre-commit' => ['enabled' => true]]);
     }
 
-    /**
-     * Tests Util::validateJsonConfiguration
-     */
     public function testActionsNoArray(): void
     {
         $this->expectException(Exception::class);
@@ -47,9 +38,6 @@ class UtilTest extends TestCase
         Util::validateJsonConfiguration(['pre-commit' => ['enabled' => true, 'actions' => false]]);
     }
 
-    /**
-     * Tests Util::validateJsonConfiguration
-     */
     public function testActionMissing(): void
     {
         $this->expectException(Exception::class);
@@ -68,9 +56,6 @@ class UtilTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Util::validateJsonConfiguration
-     */
     public function testActionEmpty(): void
     {
         $this->expectException(Exception::class);
@@ -87,9 +72,6 @@ class UtilTest extends TestCase
         );
     }
 
-    /**
-     * Tests Util::validateJsonConfiguration
-     */
     public function testConditionExecMissing(): void
     {
         $this->expectException(Exception::class);
@@ -116,9 +98,6 @@ class UtilTest extends TestCase
         );
     }
 
-    /**
-     * Tests Util::validateJsonConfiguration
-     */
     public function testConditionArgsNoArray(): void
     {
         $this->expectException(Exception::class);
@@ -143,10 +122,6 @@ class UtilTest extends TestCase
         );
     }
 
-
-    /**
-     * Tests Util::validateJsonConfiguration
-     */
     public function testValid(): void
     {
         Util::validateJsonConfiguration(
@@ -163,9 +138,6 @@ class UtilTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Util::validateJsonConfiguration
-     */
     public function testValidWithCondition(): void
     {
         Util::validateJsonConfiguration(

--- a/tests/unit/Console/ApplicationTest.php
+++ b/tests/unit/Console/ApplicationTest.php
@@ -17,11 +17,6 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class ApplicationTest extends TestCase
 {
-    /**
-     * Tests Cli::run
-     *
-     * @throws \Exception
-     */
     public function testVersionOutput(): void
     {
         $input = new ArrayInput(['--version' => true]);
@@ -37,12 +32,6 @@ class ApplicationTest extends TestCase
         $app->run($input, $output);
     }
 
-
-    /**
-     * Tests Cli::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteDefaultHelp(): void
     {
         $input = new ArrayInput(['--help' => true]);
@@ -56,11 +45,6 @@ class ApplicationTest extends TestCase
         $this->assertEquals(0, $app->run($input, $output));
     }
 
-    /**
-     * Tests Cli::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteList(): void
     {
         $input = new ArrayInput(['command' => 'list']);

--- a/tests/unit/Console/Command/AddTest.php
+++ b/tests/unit/Console/Command/AddTest.php
@@ -21,11 +21,6 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class AddTest extends TestCase
 {
-    /**
-     * Tests Add::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteNoConfig(): void
     {
         $resolver = new Resolver();
@@ -44,9 +39,6 @@ class AddTest extends TestCase
         $this->assertEquals(1, $code);
     }
 
-    /**
-     * Tests Add::run
-     */
     public function testExecutePreCommit(): void
     {
         $resolver = new Resolver();
@@ -67,7 +59,14 @@ class AddTest extends TestCase
                    ->disableOriginalConstructor()
                    ->getMock();
 
-        $io->method('ask')->will($this->onConsecutiveCalls('\\Foo\\Bar', 'n'));
+        $invokedCount = $this->atLeast(2);
+        $io->expects($invokedCount)
+           ->method('ask')
+           ->willReturnCallback(function ($parameters) use ($invokedCount) {
+               $results = ['\\Foo\\Bar', 'n'];
+               return $results[$invokedCount->numberOfInvocations() - 1] ?? '';
+           });
+
         $io->expects($this->once())->method('write');
 
         $add->setIO($io);

--- a/tests/unit/Console/Command/ConfigurationTest.php
+++ b/tests/unit/Console/Command/ConfigurationTest.php
@@ -20,17 +20,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigurationTest extends TestCase
 {
-    /**
-     * Tests Configure::run
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
-        $resolver  = new Resolver();
-        $config    = sys_get_temp_dir() . DIRECTORY_SEPARATOR . md5(mt_rand(0, 9999)) . '.json';
-        $output    = new NullOutput();
-        $input     = new ArrayInput(['--configuration' => $config]);
+        $resolver = new Resolver();
+        $config   = sys_get_temp_dir() . DIRECTORY_SEPARATOR . md5(mt_rand(0, 9999)) . '.json';
+        $output   = new NullOutput();
+        $input    = new ArrayInput(['--configuration' => $config]);
 
         $configure = new Configuration($resolver);
         $configure->setIO(new NullIO());
@@ -41,19 +36,14 @@ class ConfigurationTest extends TestCase
         unlink($config);
     }
 
-    /**
-     * Tests Configure::run
-     *
-     * @throws \Exception
-     */
     public function testConfigFailure(): void
     {
-        $resolver  = new Resolver();
-        $config    = '/foo/bar/fiz/baz/config.json';
-        $input     = new ArrayInput(['--configuration' => $config]);
-        $output    = $this->getMockBuilder(OutputInterface::class)
-                          ->disableOriginalConstructor()
-                          ->getMock();
+        $resolver = new Resolver();
+        $config   = '/foo/bar/fiz/baz/config.json';
+        $input    = new ArrayInput(['--configuration' => $config]);
+        $output   = $this->getMockBuilder(OutputInterface::class)
+                         ->disableOriginalConstructor()
+                         ->getMock();
         $output->method('isVerbose')->willReturn(true);
 
         $configure = new Configuration($resolver);

--- a/tests/unit/Console/Command/DisableTest.php
+++ b/tests/unit/Console/Command/DisableTest.php
@@ -21,11 +21,6 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class DisableTest extends TestCase
 {
-    /**
-     * Tests Enable::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteNoConfig(): void
     {
         $resolver = new Resolver();
@@ -44,9 +39,6 @@ class DisableTest extends TestCase
         $this->assertEquals(1, $code);
     }
 
-    /**
-     * Tests Enable::run
-     */
     public function testExecuteEnablePrePush(): void
     {
         $resolver = new Resolver();

--- a/tests/unit/Console/Command/EnableTest.php
+++ b/tests/unit/Console/Command/EnableTest.php
@@ -20,11 +20,6 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class EnableTest extends TestCase
 {
-    /**
-     * Tests Enable::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteNoConfig(): void
     {
         $resolver = new Resolver();
@@ -40,11 +35,6 @@ class EnableTest extends TestCase
         $this->assertEquals(1, $code);
     }
 
-    /**
-     * Tests Enable::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteEnablePrePush(): void
     {
         $resolver   = new Resolver();

--- a/tests/unit/Console/Command/Hook/CommitMsgTest.php
+++ b/tests/unit/Console/Command/Hook/CommitMsgTest.php
@@ -20,11 +20,6 @@ use PHPUnit\Framework\TestCase;
 
 class CommitMsgTest extends TestCase
 {
-    /**
-     * Tests CommitMsg::run
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
         $repo   = new DummyRepo();

--- a/tests/unit/Console/Command/Hook/PostCheckoutTest.php
+++ b/tests/unit/Console/Command/Hook/PostCheckoutTest.php
@@ -20,11 +20,6 @@ use PHPUnit\Framework\TestCase;
 
 class PostCheckoutTest extends TestCase
 {
-    /**
-     * Tests PostCheckout::run
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
         $repo   = new DummyRepo();

--- a/tests/unit/Console/Command/Hook/PostCommitTest.php
+++ b/tests/unit/Console/Command/Hook/PostCommitTest.php
@@ -19,11 +19,6 @@ use PHPUnit\Framework\TestCase;
 
 class PostCommitTest extends TestCase
 {
-    /**
-     * Tests PostCommit::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteWithRelativeConfigPath(): void
     {
         $cwd = getcwd();
@@ -46,9 +41,6 @@ class PostCommitTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests PostCommit::run
-     */
     public function testMissingBootstrapHandling(): void
     {
         $repo   = new DummyRepo();
@@ -70,10 +62,6 @@ class PostCommitTest extends TestCase
         $this->assertEquals(1, $cmd->run($input, $output));
     }
 
-
-    /**
-     * Tests PostCommit::run
-     */
     public function testCrashingBootstrapHandling(): void
     {
         if (version_compare(PHP_VERSION, '8.0', '<')) {

--- a/tests/unit/Console/Command/Hook/PostMergeTest.php
+++ b/tests/unit/Console/Command/Hook/PostMergeTest.php
@@ -19,11 +19,6 @@ use PHPUnit\Framework\TestCase;
 
 class PostMergeTest extends TestCase
 {
-    /**
-     * Tests PostMerge::run
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
         $repo   = new DummyRepo();

--- a/tests/unit/Console/Command/Hook/PreCommitTest.php
+++ b/tests/unit/Console/Command/Hook/PreCommitTest.php
@@ -23,11 +23,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PreCommitTest extends TestCase
 {
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteLib(): void
     {
         $repo   = new DummyRepo();
@@ -45,11 +40,6 @@ class PreCommitTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteSkip(): void
     {
         $repo   = new DummyRepo();
@@ -71,11 +61,6 @@ class PreCommitTest extends TestCase
         $_SERVER['CAPTAINHOOK_SKIP_HOOKS'] = 0;
     }
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testExecutePhar(): void
     {
         $resolver = $this->createMock(Resolver::class);
@@ -98,11 +83,6 @@ class PreCommitTest extends TestCase
         $this->assertTrue(defined('CH_BOOTSTRAP_WORKED'));
     }
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testExecutePharBootstrapNotFound(): void
     {
         $resolver = $this->createMock(Resolver::class);
@@ -122,9 +102,6 @@ class PreCommitTest extends TestCase
         $this->assertEquals(1, $cmd->run($input, $output));
     }
 
-    /**
-     * Tests PreCommit::run
-     */
     public function testExecutePharBootstrapNotSet(): void
     {
         $resolver = $this->createMock(Resolver::class);
@@ -143,11 +120,6 @@ class PreCommitTest extends TestCase
         $this->assertEquals(0, $cmd->run($input, $output));
     }
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteFailingActionInDebugMode(): void
     {
         $this->expectException(Exception::class);
@@ -171,11 +143,6 @@ class PreCommitTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testExecuteFailingActionInVerboseMode(): void
     {
         $output = $this->createMock(NullOutput::class);

--- a/tests/unit/Console/Command/Hook/PrePushTest.php
+++ b/tests/unit/Console/Command/Hook/PrePushTest.php
@@ -19,11 +19,6 @@ use PHPUnit\Framework\TestCase;
 
 class PrePushTest extends TestCase
 {
-    /**
-     * Tests PrePush::run
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
         $repo   = new DummyRepo();

--- a/tests/unit/Console/Command/Hook/PrepareCommitMsgTest.php
+++ b/tests/unit/Console/Command/Hook/PrepareCommitMsgTest.php
@@ -20,11 +20,6 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class PrepareCommitMsgTest extends TestCase
 {
-    /**
-     * Tests PrepareCommitMsg::run
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
         $repo   = new DummyRepo();

--- a/tests/unit/Console/Command/InstallTest.php
+++ b/tests/unit/Console/Command/InstallTest.php
@@ -22,11 +22,6 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class InstallTest extends TestCase
 {
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testFailMissingConfig(): void
     {
         $output = new NullOutput();
@@ -44,11 +39,6 @@ class InstallTest extends TestCase
         $this->assertEquals(1, $code);
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testFailInvalidRepository(): void
     {
         $output = new NullOutput();
@@ -67,11 +57,6 @@ class InstallTest extends TestCase
         $this->assertEquals(1, $code);
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testFailMissingRunExecOption(): void
     {
         $repo   = new DummyRepo();
@@ -91,12 +76,6 @@ class InstallTest extends TestCase
         $this->assertEquals(1, $code);
     }
 
-
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallPreCommitHook(): void
     {
         $repo   = new DummyRepo();
@@ -115,11 +94,6 @@ class InstallTest extends TestCase
         $this->assertTrue($repo->hookExists('pre-commit'));
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallMultipleHooks(): void
     {
         $repo   = new DummyRepo();
@@ -140,11 +114,6 @@ class InstallTest extends TestCase
         $this->assertTrue($repo->hookExists('post-checkout'));
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallMultipleHooksWithSpacesAfterAndBetweenSeparator(): void
     {
         $repo   = new DummyRepo();
@@ -165,11 +134,6 @@ class InstallTest extends TestCase
         $this->assertTrue($repo->hookExists('post-checkout'));
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallMultipleHooksWithOneWrong(): void
     {
         $repo   = new DummyRepo();
@@ -188,12 +152,6 @@ class InstallTest extends TestCase
         $this->assertEquals(1, $code);
     }
 
-
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallMultipleHooksWithMultipleWrong(): void
     {
         $repo   = new DummyRepo();
@@ -212,11 +170,6 @@ class InstallTest extends TestCase
         $this->assertEquals(1, $code);
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallOnlyEnabled(): void
     {
         $repo = new DummyRepo();
@@ -240,11 +193,6 @@ class InstallTest extends TestCase
         $this->assertFalse($repo->hookExists('post-commit'));
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallOnlyEnabledOnlyVirtual(): void
     {
         $repo = new DummyRepo();
@@ -269,11 +217,6 @@ class InstallTest extends TestCase
         $this->assertFalse($repo->hookExists('post-commit'));
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallOnlyEnabledNotOnlyVirtual(): void
     {
         $repo = new DummyRepo();
@@ -298,11 +241,6 @@ class InstallTest extends TestCase
         $this->assertFalse($repo->hookExists('post-commit'));
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallOnlyEnabledNotOnlyVirtualOverlaps(): void
     {
         $repo = new DummyRepo();
@@ -327,11 +265,6 @@ class InstallTest extends TestCase
         $this->assertFalse($repo->hookExists('post-commit'));
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallOnlyEnabledNotOnlyVirtualOverlapsDisabled(): void
     {
         $repo = new DummyRepo();
@@ -356,11 +289,6 @@ class InstallTest extends TestCase
         $this->assertFalse($repo->hookExists('post-commit'));
     }
 
-    /**
-     * Tests Install::run
-     *
-     * @throws \Exception
-     */
     public function testInstallOnlyEnabledAndHook(): void
     {
         $repo = new DummyRepo();

--- a/tests/unit/Console/Command/UninstallTest.php
+++ b/tests/unit/Console/Command/UninstallTest.php
@@ -22,11 +22,6 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class UninstallTest extends TestCase
 {
-    /**
-     * Tests Uninstall::run
-     *
-     * @throws \Exception
-     */
     public function testFailMissingConfig(): void
     {
         $output = new NullOutput();
@@ -44,11 +39,6 @@ class UninstallTest extends TestCase
         $this->assertEquals(1, $code);
     }
 
-    /**
-     * Tests Uninstall::run
-     *
-     * @throws \Exception
-     */
     public function testUninstallPreCommitHook(): void
     {
         $repo   = new DummyRepo([

--- a/tests/unit/Console/IO/CollectorIOTest.php
+++ b/tests/unit/Console/IO/CollectorIOTest.php
@@ -17,9 +17,6 @@ class CollectorIOTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests CollectorIO::getArguments
-     */
     public function testGetArguments(): void
     {
         $io  = new NullIO();
@@ -27,81 +24,57 @@ class CollectorIOTest extends TestCase
         $this->assertEquals([], $cio->getArguments());
     }
 
-    /**
-     * Tests CollectorIO::getArgument
-     */
     public function testGetArgument(): void
     {
-        $io = new NullIO();
+        $io  = new NullIO();
         $cio = new CollectorIO($io);
         $this->assertEquals('', $cio->getArgument('foo'));
         $this->assertEquals('bar', $cio->getArgument('foo', 'bar'));
     }
 
-    /**
-     * Tests CollectorIO::getStandardInput
-     */
     public function testGetStandardInput(): void
     {
-        $io = new NullIO();
+        $io  = new NullIO();
         $cio = new CollectorIO($io);
         $this->assertEquals([], $cio->getStandardInput());
     }
 
-    /**
-     * Tests CollectorIO::isInteractive
-     */
     public function testIsInteractive(): void
     {
-        $io = new NullIO();
+        $io  = new NullIO();
         $cio = new CollectorIO($io);
         $this->assertFalse($cio->isInteractive());
     }
 
-    /**
-     * Tests CollectorIO::isDebug
-     */
     public function testIsDebug(): void
     {
-        $io = new NullIO();
+        $io  = new NullIO();
         $cio = new CollectorIO($io);
         $this->assertFalse($cio->isDebug());
     }
 
-    /**
-     * Tests CollectorIO::isVerbose
-     */
     public function testIsVerbose(): void
     {
-        $io = new NullIO();
+        $io  = new NullIO();
         $cio = new CollectorIO($io);
         $this->assertFalse($cio->isVerbose());
     }
 
-    /**
-     * Tests CollectorIO::isVeryVerbose
-     */
     public function testIsVeryVerbose(): void
     {
-        $io = new NullIO();
+        $io  = new NullIO();
         $cio = new CollectorIO($io);
         $this->assertFalse($cio->isVeryVerbose());
     }
 
-    /**
-     * Tests CollectorIO::writeError
-     */
     public function testWriteError(): void
     {
-        $io = new NullIO();
+        $io  = new NullIO();
         $cio = new CollectorIO($io);
         $cio->writeError('foo');
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests CollectorIO::ask
-     */
     public function testAsk(): void
     {
         $io  = new NullIO();
@@ -109,9 +82,6 @@ class CollectorIOTest extends TestCase
         $this->assertEquals('bar', $cio->ask('foo', 'bar'));
     }
 
-    /**
-     * Tests CollectorIO::askConfirmation
-     */
     public function testAskConfirmation(): void
     {
         $io  = new NullIO();
@@ -119,11 +89,6 @@ class CollectorIOTest extends TestCase
         $this->assertEquals(true, $cio->askConfirmation('foo', true));
     }
 
-    /**
-     * Tests CollectorIO::askAbdValidate
-     *
-     * @throws \Exception
-     */
     public function testAskAndValidate(): void
     {
         $io  = new NullIO();

--- a/tests/unit/Console/IO/ComposerIOTest.php
+++ b/tests/unit/Console/IO/ComposerIOTest.php
@@ -21,9 +21,6 @@ class ComposerIOTest extends TestCase
      */
     private $io;
 
-    /**
-     * Test setup
-     */
     protected function setUp(): void
     {
         $mock = $this->getMockBuilder(IOInterface::class)
@@ -39,49 +36,31 @@ class ComposerIOTest extends TestCase
         $this->io = new ComposerIO($mock);
     }
 
-    /**
-     * Test tear down
-     */
     protected function tearDown(): void
     {
         $this->io = null;
     }
 
-    /**
-     * Tests ComposerIO::isInteractive
-     */
     public function testIsInteractive(): void
     {
         $this->assertFalse($this->io->isInteractive());
     }
 
-    /**
-     * Tests ComposerIO::isDebug
-     */
     public function testIsDebug(): void
     {
         $this->assertFalse($this->io->isDebug());
     }
 
-    /**
-     * Tests ComposerIO::isVerbose
-     */
     public function testIsVerbose(): void
     {
         $this->assertFalse($this->io->isVerbose());
     }
 
-    /**
-     * Tests ComposerIO::isVeryVerbose
-     */
     public function testIsVeryVerbose(): void
     {
         $this->assertFalse($this->io->isVeryVerbose());
     }
 
-    /**
-     * Tests ComposerIO::write
-     */
     public function testWrite(): void
     {
         $this->io->write('foo');
@@ -89,9 +68,6 @@ class ComposerIOTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests ComposerIO::writeError
-     */
     public function testWriteError(): void
     {
         $this->io->writeError('foo');
@@ -99,27 +75,16 @@ class ComposerIOTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests ComposerIO::ask
-     */
     public function testAsk(): void
     {
         $this->assertEquals('bar', $this->io->ask('foo', 'bar'));
     }
 
-    /**
-     * Tests ComposerIO::askConfirmation
-     */
     public function testAskConfirmation(): void
     {
         $this->assertEquals(true, $this->io->askConfirmation('foo', true));
     }
 
-    /**
-     * Tests ComposerIO::askAbdValidate
-     *
-     * @throws \Exception
-     */
     public function testAskAndValidate(): void
     {
         $this->assertEquals(

--- a/tests/unit/Console/IO/DefaultIOTest.php
+++ b/tests/unit/Console/IO/DefaultIOTest.php
@@ -73,9 +73,6 @@ class DefaultIOTest extends TestCase
                     ->getMock();
     }
 
-    /**
-     * Tests DefaultIO::getArguments
-     */
     public function testGetArguments(): void
     {
         $input  = $this->getInputMock();
@@ -88,9 +85,6 @@ class DefaultIOTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $io->getArguments());
     }
 
-    /**
-     * Tests DefaultIO::getArgument
-     */
     public function testGetArgument(): void
     {
         $input  = $this->getInputMock();
@@ -104,10 +98,6 @@ class DefaultIOTest extends TestCase
         $this->assertEquals('bar', $io->getArgument('fiz', 'bar'));
     }
 
-
-    /**
-     * Tests DefaultIO::getStandardInput
-     */
     public function testGetStandardInput(): void
     {
         $input  = $this->getInputMock();
@@ -123,9 +113,6 @@ class DefaultIOTest extends TestCase
         $this->assertCount(3, $io->getStandardInput());
     }
 
-    /**
-     * Tests DefaultIO::isInteractive
-     */
     public function testIsInteractive(): void
     {
         $input  = $this->getInputMock();
@@ -138,9 +125,6 @@ class DefaultIOTest extends TestCase
         $this->assertFalse($io->isInteractive());
     }
 
-    /**
-     * Tests DefaultIO::isVerbose
-     */
     public function testIsVerbose(): void
     {
         $input  = $this->getInputMock();
@@ -153,9 +137,6 @@ class DefaultIOTest extends TestCase
         $this->assertFalse($io->isVerbose());
     }
 
-    /**
-     * Tests DefaultIO::isVeryVerbose
-     */
     public function testIsVeryVerbose(): void
     {
         $input  = $this->getInputMock();
@@ -168,9 +149,6 @@ class DefaultIOTest extends TestCase
         $this->assertFalse($io->isVeryVerbose());
     }
 
-    /**
-     * Tests DefaultIO::isDebug
-     */
     public function testIsDebug(): void
     {
         $input  = $this->getInputMock();
@@ -183,9 +161,6 @@ class DefaultIOTest extends TestCase
         $this->assertFalse($io->isDebug());
     }
 
-    /**
-     * Tests DefaultIO::writeError
-     */
     public function testWriteError(): void
     {
         $input  = $this->getInputMock();
@@ -198,9 +173,6 @@ class DefaultIOTest extends TestCase
         $io->writeError('foo');
     }
 
-    /**
-     * Tests DefaultIO::ask
-     */
     public function testAsk(): void
     {
         $input          = $this->getInputMock();
@@ -236,7 +208,6 @@ class DefaultIOTest extends TestCase
         $io->askConfirmation('foo');
     }
 
-
     public function testAskAndValidateNoHelper(): void
     {
         $this->expectException(Exception::class);
@@ -252,9 +223,6 @@ class DefaultIOTest extends TestCase
         );
     }
 
-    /**
-     * Tests DefaultIO::askConfirmation
-     */
     public function testAskConfirmation(): void
     {
         $input          = $this->getInputMock();
@@ -270,11 +238,6 @@ class DefaultIOTest extends TestCase
         $this->assertTrue($answer);
     }
 
-    /**
-     * Tests DefaultIO::askAbdValidate
-     *
-     * @throws \Exception
-     */
     public function testAskAndValidate(): void
     {
         $input          = $this->getInputMock();
@@ -295,14 +258,11 @@ class DefaultIOTest extends TestCase
         $this->assertEquals('y', $answer);
     }
 
-    /**
-     * Tests DefaultIO::write
-     */
     public function testWrite(): void
     {
-        $input          = $this->getInputMock();
-        $output         = $this->getConsoleOutputMock();
-        $helper         = $this->getHelperSetMock();
+        $input  = $this->getInputMock();
+        $output = $this->getConsoleOutputMock();
+        $helper = $this->getHelperSetMock();
 
         $output->expects($this->once())->method('getVerbosity')->willReturn(OutputInterface::VERBOSITY_DEBUG);
         $output->expects($this->once())->method('getErrorOutput')->willReturn($this->getOutputMock());
@@ -311,15 +271,11 @@ class DefaultIOTest extends TestCase
         $io->writeError('foo');
     }
 
-
-    /**
-     * Tests DefaultIO::write
-     */
     public function testWriteSkipped(): void
     {
-        $input          = $this->getInputMock();
-        $output         = $this->getConsoleOutputMock();
-        $helper         = $this->getHelperSetMock();
+        $input  = $this->getInputMock();
+        $output = $this->getConsoleOutputMock();
+        $helper = $this->getHelperSetMock();
 
         $output->expects($this->once())->method('getVerbosity')->willReturn(OutputInterface::VERBOSITY_NORMAL);
         $output->expects($this->exactly(0))->method('getErrorOutput');

--- a/tests/unit/Console/IO/NullIOTest.php
+++ b/tests/unit/Console/IO/NullIOTest.php
@@ -15,18 +15,12 @@ use PHPUnit\Framework\TestCase;
 
 class NullIOTest extends TestCase
 {
-    /**
-     * Tests NullIO::getArguments
-     */
     public function testGetArguments(): void
     {
         $io = new NullIO();
         $this->assertEquals([], $io->getArguments());
     }
 
-    /**
-     * Tests NullIO::getArgument
-     */
     public function testGetArgument(): void
     {
         $io = new NullIO();
@@ -34,54 +28,36 @@ class NullIOTest extends TestCase
         $this->assertEquals('bar', $io->getArgument('foo', 'bar'));
     }
 
-    /**
-     * Tests NullIO::getStandardInput
-     */
     public function testGetStandardInput(): void
     {
         $io = new NullIO();
         $this->assertEquals([], $io->getStandardInput());
     }
 
-    /**
-     * Tests NullIO::isInteractive
-     */
     public function testIsInteractive(): void
     {
         $io = new NullIO();
         $this->assertFalse($io->isInteractive());
     }
 
-    /**
-     * Tests NullIO::isDebug
-     */
     public function testIsDebug(): void
     {
         $io = new NullIO();
         $this->assertFalse($io->isDebug());
     }
 
-    /**
-     * Tests NullIO::isVerbose
-     */
     public function testIsVerbose(): void
     {
         $io = new NullIO();
         $this->assertFalse($io->isVerbose());
     }
 
-    /**
-     * Tests NullIO::isVeryVerbose
-     */
     public function testIsVeryVerbose(): void
     {
         $io = new NullIO();
         $this->assertFalse($io->isVeryVerbose());
     }
 
-    /**
-     * Tests NullIO::writeError
-     */
     public function testWriteError(): void
     {
         $io = new NullIO();
@@ -89,29 +65,18 @@ class NullIOTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests NullIO::ask
-     */
     public function testAsk(): void
     {
         $io = new NullIO();
         $this->assertEquals('bar', $io->ask('foo', 'bar'));
     }
 
-    /**
-     * Tests NullIO::askConfirmation
-     */
     public function testAskConfirmation(): void
     {
         $io = new NullIO();
         $this->assertEquals(true, $io->askConfirmation('foo', true));
     }
 
-    /**
-     * Tests NullIO::askAbdValidate
-     *
-     * @throws \Exception
-     */
     public function testAskAndValidate(): void
     {
         $io = new NullIO();

--- a/tests/unit/Console/IOUtilTest.php
+++ b/tests/unit/Console/IOUtilTest.php
@@ -16,9 +16,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class IOUtilTest extends TestCase
 {
-    /**
-     * Tests IOUtil::mapConfigVerbosity
-     */
     public function testMapConfigVerbosity(): void
     {
         $this->assertEquals(OutputInterface::VERBOSITY_QUIET, IOUtil::mapConfigVerbosity('quiet'));
@@ -27,17 +24,11 @@ class IOUtilTest extends TestCase
         $this->assertEquals(OutputInterface::VERBOSITY_DEBUG, IOUtil::mapConfigVerbosity('debug'));
     }
 
-    /**
-     * Tests IOUtil::mapConfigVerbosity
-     */
     public function testMapConfigVerbosityNotFound(): void
     {
         $this->assertEquals(OutputInterface::VERBOSITY_NORMAL, IOUtil::mapConfigVerbosity('foobar'));
     }
 
-    /**
-     * Tests IOUtil::answerToBool
-     */
     public function testAnswerToBool(): void
     {
         $this->assertTrue(IOUtil::answerToBool('y'));
@@ -47,9 +38,6 @@ class IOUtilTest extends TestCase
         $this->assertFalse(IOUtil::answerToBool('foo'));
     }
 
-    /**
-     * Tests IOUtil::formatHeadline
-     */
     public function testFormatHeadlineLong(): void
     {
         $long     = str_repeat('x', 90);
@@ -58,9 +46,6 @@ class IOUtilTest extends TestCase
         $this->assertEquals($long, $headline);
     }
 
-    /**
-     * Tests IOUtil::formatHeadline
-     */
     public function testFormatHeadlineShort(): void
     {
         $text     = str_repeat('x', 70) ;

--- a/tests/unit/Event/DispatcherTest.php
+++ b/tests/unit/Event/DispatcherTest.php
@@ -22,9 +22,6 @@ class DispatcherTest extends TestCase
     use CHMockery;
     use IOMockery;
 
-    /**
-     * Tests Dispatcher::subscribeHandlers
-     */
     public function testSubscribeHandlers(): void
     {
         $io      = $this->createIOMock();

--- a/tests/unit/Event/FactoryTest.php
+++ b/tests/unit/Event/FactoryTest.php
@@ -23,9 +23,6 @@ class FactoryTest extends TestCase
     use CHMockery;
     use IOMockery;
 
-    /**
-     * Tests HookFailed
-     */
     public function testCreateEvent(): void
     {
         $io     = $this->createIOMock();
@@ -38,9 +35,6 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(HookFailed::class, $event);
     }
 
-    /**
-     * Tests HookFailed
-     */
     public function testInvalidEvent(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Event/HookFailedTest.php
+++ b/tests/unit/Event/HookFailedTest.php
@@ -22,9 +22,6 @@ class HookFailedTest extends TestCase
     use CHMockery;
     use IOMockery;
 
-    /**
-     * Tests HookFailed
-     */
     public function testEvent(): void
     {
         $io     = $this->createIOMock();

--- a/tests/unit/Git/ChangedFiles/Detector/FallbackTest.php
+++ b/tests/unit/Git/ChangedFiles/Detector/FallbackTest.php
@@ -30,9 +30,6 @@ class FallbackTest extends TestCase
 {
     use IOMockery;
 
-    /**
-     * Tests: Fallback::getRanges
-     */
     public function testGetRanges()
     {
         $io = $this->createIOMock();

--- a/tests/unit/Git/ChangedFiles/Detector/PrePushTest.php
+++ b/tests/unit/Git/ChangedFiles/Detector/PrePushTest.php
@@ -28,9 +28,6 @@ class PrePushTest extends TestCase
     use IOMockery;
     use AppMockery;
 
-    /**
-     * Tests: PrePush::getChangedFiles
-     */
     public function testGetChangedFilesNoRanges(): void
     {
         $io    = $this->createIOMock();
@@ -46,9 +43,6 @@ class PrePushTest extends TestCase
         $this->assertEquals([], $files);
     }
 
-    /**
-     * Tests: PrePush::getChangedFiles
-     */
     public function testGetChangedFilesRemoteExists(): void
     {
         $io    = $this->createIOMock();
@@ -74,9 +68,6 @@ class PrePushTest extends TestCase
         $this->assertEquals('foo.txt', $files[0]);
     }
 
-    /**
-     * Tests: PrePush::getChangedFiles
-     */
     public function testGetChangedFilesNewBranch(): void
     {
         $io    = $this->createIOMock();
@@ -107,10 +98,6 @@ class PrePushTest extends TestCase
         $this->assertEquals('foo.txt', $files[0]);
     }
 
-
-    /**
-     * Tests: PrePush::getChangedFiles
-     */
     public function testGetChangedFilesNewBranchNoReflog(): void
     {
         $io    = $this->createIOMock();

--- a/tests/unit/Git/Diff/FilterUtilTest.php
+++ b/tests/unit/Git/Diff/FilterUtilTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class FilterUtilTest extends TestCase
 {
-    /**
-     * Tests FilterUtil::sanitize
-     */
     public function testSanitize(): void
     {
         $sanitized = FilterUtil::sanitize(['A', 'C', 'Z']);
@@ -27,9 +24,6 @@ class FilterUtilTest extends TestCase
         $this->assertTrue(in_array('C', $sanitized));
     }
 
-    /**
-     * Tests FilterUtil::sanitize
-     */
     public function testSanitizeEmpty(): void
     {
         $sanitized = FilterUtil::sanitize(['Q', 'L', 'Z']);
@@ -37,9 +31,6 @@ class FilterUtilTest extends TestCase
         $this->assertEmpty($sanitized);
     }
 
-    /**
-     * Tests FilterUtil::filterFromConfigValue
-     */
     public function testFromConfigValue(): void
     {
         $this->assertEmpty(FilterUtil::filterFromConfigValue('FOO'));

--- a/tests/unit/Git/DummyRepo.php
+++ b/tests/unit/Git/DummyRepo.php
@@ -12,6 +12,7 @@
 namespace CaptainHook\App\Git;
 
 use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 
 class DummyRepo
 {
@@ -20,14 +21,14 @@ class DummyRepo
      *
      * @var string
      */
-    private $path;
+    private string $path;
 
     /**
      * Default empty hook git dir structure
      *
      * @var array
      */
-    private static $defaultStructure = [
+    private static array $defaultStructure = [
         'config' => '# fake git config',
         'hooks'  => [
             'pre-commit.sample' => '# fake pre-commit sample file',
@@ -40,7 +41,7 @@ class DummyRepo
      *
      * @var \org\bovigo\vfs\vfsStreamDirectory
      */
-    private $repo;
+    private vfsStreamDirectory $repo;
 
     /**
      * DummyRepo constructor
@@ -61,7 +62,7 @@ class DummyRepo
      * @param  array $files
      * @return array
      */
-    private function setupRepo(array $gitDir, array $files)
+    private function setupRepo(array $gitDir, array $files): array
     {
         $dotGit = empty($gitDir) ? self::$defaultStructure : $gitDir;
 
@@ -87,7 +88,7 @@ class DummyRepo
      *
      * @return string
      */
-    public function getRoot()
+    public function getRoot(): string
     {
         return $this->path;
     }
@@ -97,7 +98,7 @@ class DummyRepo
      *
      * @return string
      */
-    public function getGitDir()
+    public function getGitDir(): string
     {
         return $this->getRoot() . '/.git';
     }
@@ -107,7 +108,7 @@ class DummyRepo
      *
      * @return string
      */
-    public function getHookDir()
+    public function getHookDir(): string
     {
         return $this->getGitDir() . '/hooks';
     }

--- a/tests/unit/Git/Rev/PrePushTest.php
+++ b/tests/unit/Git/Rev/PrePushTest.php
@@ -23,9 +23,6 @@ use PHPUnit\Framework\TestCase;
  */
 class PrePushTest extends TestCase
 {
-    /**
-     * Tests all ref getters
-     */
     public function testGetter(): void
     {
         $ref = new PrePush('refs/heads/main', '12345', 'main');

--- a/tests/unit/Git/Rev/UtilTest.php
+++ b/tests/unit/Git/Rev/UtilTest.php
@@ -18,9 +18,6 @@ use PHPUnit\Framework\TestCase;
  */
 class UtilTest extends TestCase
 {
-    /**
-     * Tests: Util::isZeroHash
-     */
     public function testIsZeroHash()
     {
         $this->assertTrue(Util::isZeroHash('00000000000000000'));
@@ -28,9 +25,6 @@ class UtilTest extends TestCase
         $this->assertFalse(Util::isZeroHash('ef65da'));
     }
 
-    /**
-     * Tests: Util::extractBranchInfo
-     */
     public function testExtractBranchInfoDefaultRemote()
     {
         $info = Util::extractBranchInfo('foo-bar-baz');
@@ -38,9 +32,6 @@ class UtilTest extends TestCase
         $this->assertEquals('foo-bar-baz', $info['branch']);
     }
 
-    /**
-     * Tests: Util::extractBranchInfo
-     */
     public function testExtractBranchInfoWithRef()
     {
         $info = Util::extractBranchInfo('refs/origin/foo');
@@ -48,9 +39,6 @@ class UtilTest extends TestCase
         $this->assertEquals('foo', $info['branch']);
     }
 
-    /**
-     * Tests: Util::extractBranchInfo
-     */
     public function testExtractBranchInfoWithSlashInBranchName()
     {
         $info = Util::extractBranchInfo('refs/source/feature/foo');

--- a/tests/unit/Hook/Branch/Action/BlockFixupAndSquashCommitsTest.php
+++ b/tests/unit/Hook/Branch/Action/BlockFixupAndSquashCommitsTest.php
@@ -26,18 +26,12 @@ class BlockFixupAndSquashCommitsTest extends TestCase
     use IOMockery;
     use ConfigMockery;
 
-    /**
-     * Tests BlockFixupAndSquashCommits::getRestriction
-     */
     public function testConstraint(): void
     {
         $this->assertTrue(BlockFixupAndSquashCommits::getRestriction()->isApplicableFor('pre-push'));
         $this->assertFalse(BlockFixupAndSquashCommits::getRestriction()->isApplicableFor('pre-commit'));
     }
 
-    /**
-     * Tests BlockFixupAndSquashCommits::execute
-     */
     public function testExecuteSuccess(): void
     {
         $input    = ['refs/heads/main 12345 refs/heads/main 98765'];
@@ -57,9 +51,6 @@ class BlockFixupAndSquashCommitsTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests BlockFixupAndSquashCommits::execute
-     */
     public function testExecuteSuccessBecauseOfUnprotectedBranch(): void
     {
         $input    = ['refs/heads/foo 12345 refs/heads/foo 98765'];
@@ -80,9 +71,6 @@ class BlockFixupAndSquashCommitsTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests BlockFixupAndSquashCommits::execute
-     */
     public function testExecuteSuccessWithNoChangesFromLocalAndRemote(): void
     {
         $input    = ['refs/tags/5.14.2 4d89c05 refs/tags/5.14.2 0000000000000000000000000000000000000000'];
@@ -102,9 +90,6 @@ class BlockFixupAndSquashCommitsTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests BlockFixupAndSquashCommits::execute
-     */
     public function testExecuteBlockFixup(): void
     {
         $this->expectException(Exception::class);
@@ -124,9 +109,6 @@ class BlockFixupAndSquashCommitsTest extends TestCase
         $blocker->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests BlockFixupAndSquashCommits::execute
-     */
     public function testExecuteBlockFixupForProtectedBranch(): void
     {
         $this->expectException(Exception::class);
@@ -147,9 +129,6 @@ class BlockFixupAndSquashCommitsTest extends TestCase
         $blocker->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests BlockFixupAndSquashCommits::execute
-     */
     public function testExecuteBlockSquash(): void
     {
         $this->expectException(Exception::class);
@@ -169,9 +148,6 @@ class BlockFixupAndSquashCommitsTest extends TestCase
         $blocker->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests BlockFixupAndSquashCommits::execute
-     */
     public function testExecuteNoPushInfo(): void
     {
         $input    = [''];

--- a/tests/unit/Hook/Branch/Action/EnsureNamingTest.php
+++ b/tests/unit/Hook/Branch/Action/EnsureNamingTest.php
@@ -21,9 +21,6 @@ class EnsureNamingTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests EnsureNaming::getRestriction
-     */
     public function testConstraint(): void
     {
         $this->assertTrue(EnsureNaming::getRestriction()->isApplicableFor('pre-commit'));
@@ -32,11 +29,6 @@ class EnsureNamingTest extends TestCase
         $this->assertFalse(EnsureNaming::getRestriction()->isApplicableFor('post-commit'));
     }
 
-    /**
-     * Tests EnsureNaming::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteDefaultSuccess(): void
     {
         $io = $this->createPartialMock(NullIO::class, ['write']);
@@ -57,11 +49,6 @@ class EnsureNamingTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests EnsureNaming::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteCustomSuccess(): void
     {
         $successMessage = 'Regex matched';
@@ -88,11 +75,6 @@ class EnsureNamingTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests EnsureNaming::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteInvalidOption(): void
     {
         $this->expectException(Exception::class);
@@ -106,11 +88,6 @@ class EnsureNamingTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests EnsureNaming::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteNoMatchDefaultErrorMessage(): void
     {
         $this->expectException(Exception::class);
@@ -128,11 +105,6 @@ class EnsureNamingTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests EnsureNaming::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteNoMatchCustomErrorMessage(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Composer/Action/CheckLockFileTest.php
+++ b/tests/unit/Hook/Composer/Action/CheckLockFileTest.php
@@ -21,11 +21,6 @@ class CheckLockFileTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests CheckLockFile::execute
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
         $io     = new NullIO();
@@ -41,11 +36,6 @@ class CheckLockFileTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests CheckLockFile::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteFail(): void
     {
         $this->expectException(Exception::class);
@@ -62,12 +52,6 @@ class CheckLockFileTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-
-    /**
-     * Tests CheckLockFile::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteNoHash(): void
     {
         $this->expectException(Exception::class);
@@ -84,11 +68,6 @@ class CheckLockFileTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests CheckLockFile::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteInvalidPath(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Condition/Branch/FilesTest.php
+++ b/tests/unit/Hook/Condition/Branch/FilesTest.php
@@ -20,9 +20,6 @@ class FilesTest extends TestCase
     use AppMockery;
     use IOMockery;
 
-    /**
-     * Tests Files::isTrue
-     */
     public function testBranchFilesWithReflog(): void
     {
         $io   = $this->createIOMock();
@@ -47,9 +44,6 @@ class FilesTest extends TestCase
         $this->assertTrue($files->isTrue($io, $repo));
     }
 
-    /**
-     * Tests Files::isTrue
-     */
     public function testBranchFilesWithEmptyReflog(): void
     {
         $io   = $this->createIOMock();
@@ -71,9 +65,6 @@ class FilesTest extends TestCase
         $this->assertFalse($files->isTrue($io, $repo));
     }
 
-    /**
-     * Tests Files::isTrue
-     */
     public function testComparedToInDirectory(): void
     {
         $io   = $this->createIOMock();

--- a/tests/unit/Hook/Condition/Branch/NotOnMatchingTest.php
+++ b/tests/unit/Hook/Condition/Branch/NotOnMatchingTest.php
@@ -20,9 +20,6 @@ class NotOnMatchingTest extends TestCase
     use IOMockery;
     use AppMockery;
 
-    /**
-     * Tests NotOnMatching::isTrue
-     */
     public function testConditionFalse(): void
     {
         $io           = $this->createIOMock();
@@ -35,9 +32,6 @@ class NotOnMatchingTest extends TestCase
         $this->assertFalse($condition->isTrue($io, $repository));
     }
 
-    /**
-     * Tests NotOnMatching::isTrue
-     */
     public function testConditionTrue(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Hook/Condition/Branch/NotOnTest.php
+++ b/tests/unit/Hook/Condition/Branch/NotOnTest.php
@@ -20,9 +20,6 @@ class NotOnTest extends TestCase
     use IOMockery;
     use AppMockery;
 
-    /**
-     * Tests NotOn::isTrue
-     */
     public function testConditionFalse(): void
     {
         $io           = $this->createIOMock();
@@ -36,9 +33,6 @@ class NotOnTest extends TestCase
         $this->assertFalse($condition->isTrue($io, $repository));
     }
 
-    /**
-     * Tests NotOn::isTrue
-     */
     public function testConditionTrue(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Hook/Condition/Branch/OnMatchingTest.php
+++ b/tests/unit/Hook/Condition/Branch/OnMatchingTest.php
@@ -20,9 +20,6 @@ class OnMatchingTest extends TestCase
     use IOMockery;
     use AppMockery;
 
-    /**
-     * Tests OnByRegex::isTrue
-     */
     public function testConditionTrue(): void
     {
         $io           = $this->createIOMock();
@@ -36,9 +33,6 @@ class OnMatchingTest extends TestCase
         $this->assertTrue($condition->isTrue($io, $repository));
     }
 
-    /**
-     * Tests OnByRegex::isTrue
-     */
     public function testConditionFalse(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Hook/Condition/Branch/OnTest.php
+++ b/tests/unit/Hook/Condition/Branch/OnTest.php
@@ -20,9 +20,6 @@ class OnTest extends TestCase
     use IOMockery;
     use AppMockery;
 
-    /**
-     * Tests On::isTrue
-     */
     public function testConditionTrue(): void
     {
         $io           = $this->createIOMock();
@@ -36,9 +33,6 @@ class OnTest extends TestCase
         $this->assertTrue($condition->isTrue($io, $repository));
     }
 
-    /**
-     * Tests On::isTrue
-     */
     public function testConditionFalse(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Hook/Condition/Config/CustomValueIsFalsyTest.php
+++ b/tests/unit/Hook/Condition/Config/CustomValueIsFalsyTest.php
@@ -24,9 +24,6 @@ class CustomValueIsFalsyTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests CustomValueIsTruthy::isTrue
-     */
     public function testCustomValueIsTruthyIsTrue(): void
     {
         $io         = $this->createIOMock();
@@ -47,9 +44,6 @@ class CustomValueIsFalsyTest extends TestCase
         $this->assertTrue($condition->isTrue($io, $repository));
     }
 
-    /**
-     * Tests CustomValueIsTruthy::isTrue
-     */
     public function testIsTrueFailure(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Condition/Config/CustomValueIsTruthyTest.php
+++ b/tests/unit/Hook/Condition/Config/CustomValueIsTruthyTest.php
@@ -24,9 +24,6 @@ class CustomValueIsTruthyTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests CustomValueIsTruthy::isTrue
-     */
     public function testCustomValueIsTruthyIsTrue(): void
     {
         $io         = $this->createIOMock();
@@ -47,9 +44,6 @@ class CustomValueIsTruthyTest extends TestCase
         $this->assertFalse($condition->isTrue($io, $repository));
     }
 
-    /**
-     * Tests CustomValueIsTruthy::isTrue
-     */
     public function testIsTrueFailure(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Condition/FileChanged/AllTest.php
+++ b/tests/unit/Hook/Condition/FileChanged/AllTest.php
@@ -20,9 +20,6 @@ class AllTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests All::isTrue
-     */
     public function testIsFalse(): void
     {
         $io = $this->createIOMock();
@@ -36,9 +33,6 @@ class AllTest extends TestCase
         $this->assertFalse($fileChange->isTrue($io, $repository));
     }
 
-    /**
-     * Tests All::isTrue
-     */
     public function testWithWildcardIsFalse(): void
     {
         $io = $this->createIOMock();
@@ -52,9 +46,6 @@ class AllTest extends TestCase
         $this->assertFalse($fileChange->isTrue($io, $repository));
     }
 
-    /**
-     * Tests All::isTrue
-     */
     public function testIsTrue(): void
     {
         $io = $this->createIOMock();
@@ -68,9 +59,6 @@ class AllTest extends TestCase
         $this->assertTrue($fileChange->isTrue($io, $repository));
     }
 
-    /**
-     * Tests All::isTrue
-     */
     public function testWithWildcardIsTrue(): void
     {
         $io = $this->createIOMock();

--- a/tests/unit/Hook/Condition/FileChanged/AnyTest.php
+++ b/tests/unit/Hook/Condition/FileChanged/AnyTest.php
@@ -20,9 +20,6 @@ class AnyTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testIsTrue(): void
     {
         $io = $this->createIOMock();
@@ -36,9 +33,6 @@ class AnyTest extends TestCase
         $this->assertTrue($fileChange->isTrue($io, $repository));
     }
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testIsTrueAfterRewrite(): void
     {
         $io = $this->createIOMock();
@@ -53,9 +47,6 @@ class AnyTest extends TestCase
         $this->assertTrue($fileChange->isTrue($io, $repository));
     }
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testWithWildcardIsTrue(): void
     {
         $io = $this->createIOMock();
@@ -69,9 +60,6 @@ class AnyTest extends TestCase
         $this->assertTrue($fileChange->isTrue($io, $repository));
     }
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testIsFalse(): void
     {
         $io = $this->createIOMock();
@@ -85,9 +73,6 @@ class AnyTest extends TestCase
         $this->assertFalse($fileChange->isTrue($io, $repository));
     }
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testWithWildcardIsFalse(): void
     {
         $io = $this->createIOMock();

--- a/tests/unit/Hook/Condition/FileChanged/OfTypeTest.php
+++ b/tests/unit/Hook/Condition/FileChanged/OfTypeTest.php
@@ -28,18 +28,12 @@ class OfTypeTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests OfType::getRestriction
-     */
     public function testRestriction(): void
     {
         $this->assertTrue(OfType::getRestriction()->isApplicableFor('pre-push'));
         $this->assertFalse(OfType::getRestriction()->isApplicableFor('pre-commit'));
     }
 
-    /**
-     * Tests OfType::isTrue
-     */
     public function testIsTrue(): void
     {
         $io = $this->createIOMock();
@@ -60,9 +54,6 @@ class OfTypeTest extends TestCase
         $this->assertTrue($fileChange->isTrue($io, $repository));
     }
 
-    /**
-     * Tests OfType::isTrue
-     */
     public function testChangedFileButNoneOfType(): void
     {
         $io = $this->createIOMock();
@@ -84,10 +75,6 @@ class OfTypeTest extends TestCase
         $this->assertFalse($fileChange->isTrue($io, $repository));
     }
 
-
-    /**
-     * Tests OfType::isTrue
-     */
     public function testIsZeroHash(): void
     {
         $io = $this->createIOMock();
@@ -107,9 +94,6 @@ class OfTypeTest extends TestCase
         $this->assertFalse($fileChange->isTrue($io, $repository));
     }
 
-    /**
-     * Tests OfType::isTrue
-     */
     public function testIsFalse(): void
     {
         $io = $this->createIOMock();

--- a/tests/unit/Hook/Condition/FileStaged/AllTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/AllTest.php
@@ -20,18 +20,12 @@ class AllTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests OfType::getRestriction
-     */
     public function testPreCommitRestriction(): void
     {
         $this->assertTrue(All::getRestriction()->isApplicableFor('pre-commit'));
         $this->assertFalse(All::getRestriction()->isApplicableFor('pre-push'));
     }
 
-    /**
-     * Tests All::isTrue
-     */
     public function testIsFalse(): void
     {
         $io         = $this->createIOMock();
@@ -44,9 +38,6 @@ class AllTest extends TestCase
         $this->assertFalse($fileStaged->isTrue($io, $repository));
     }
 
-    /**
-     * Tests All::isTrue
-     */
     public function testWithWildcardIsFalse(): void
     {
         $io         = $this->createIOMock();
@@ -59,9 +50,6 @@ class AllTest extends TestCase
         $this->assertFalse($fileStaged->isTrue($io, $repository));
     }
 
-    /**
-     * Tests All::isTrue
-     */
     public function testIsTrue(): void
     {
         $io         = $this->createIOMock();
@@ -74,9 +62,6 @@ class AllTest extends TestCase
         $this->assertTrue($fileStaged->isTrue($io, $repository));
     }
 
-    /**
-     * Tests All::isTrue
-     */
     public function testWithWildcardIsTrue(): void
     {
         $io = $this->createIOMock();

--- a/tests/unit/Hook/Condition/FileStaged/AnyTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/AnyTest.php
@@ -20,9 +20,6 @@ class AnyTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testIsTrue(): void
     {
         $io = $this->createIOMock();
@@ -35,9 +32,6 @@ class AnyTest extends TestCase
         $this->assertTrue($fileStaged->isTrue($io, $repository));
     }
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testIsTrueWithStringFilter(): void
     {
         $io = $this->createIOMock();
@@ -50,9 +44,6 @@ class AnyTest extends TestCase
         $this->assertTrue($fileStaged->isTrue($io, $repository));
     }
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testWithWildcardIsTrue(): void
     {
         $io = $this->createIOMock();
@@ -65,9 +56,6 @@ class AnyTest extends TestCase
         $this->assertTrue($fileStaged->isTrue($io, $repository));
     }
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testIsFalse(): void
     {
         $io = $this->createIOMock();
@@ -80,9 +68,6 @@ class AnyTest extends TestCase
         $this->assertFalse($fileStaged->isTrue($io, $repository));
     }
 
-    /**
-     * Tests Any::isTrue
-     */
     public function testWithWildcardIsFalse(): void
     {
         $io = $this->createIOMock();

--- a/tests/unit/Hook/Condition/FileStaged/InDirectoryTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/InDirectoryTest.php
@@ -20,18 +20,12 @@ class InDirectoryTest extends TestCase
     use AppMockery;
     use IOMockery;
 
-    /**
-     * Tests InDirectory::getRestriction
-     */
     public function testPreCommitRestriction(): void
     {
         $this->assertTrue(InDirectory::getRestriction()->isApplicableFor('pre-commit'));
         $this->assertFalse(InDirectory::getRestriction()->isApplicableFor('pre-push'));
     }
 
-    /**
-     * Tests InDirectory::isTrue
-     */
     public function testStagedTrue(): void
     {
         $io    = $this->createIOMock();
@@ -43,9 +37,6 @@ class InDirectoryTest extends TestCase
         $this->assertTrue($condition->isTrue($io, $repo));
     }
 
-    /**
-     * Tests InDirectory:isTrue
-     */
     public function testStagedFalse(): void
     {
         $io    = $this->createIOMock();

--- a/tests/unit/Hook/Condition/FileStaged/OfTypeTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/OfTypeTest.php
@@ -20,18 +20,12 @@ class OfTypeTest extends TestCase
     use AppMockery;
     use IOMockery;
 
-    /**
-     * Tests OfType::getRestriction
-     */
     public function testPreCommitRestriction(): void
     {
         $this->assertTrue(OfType::getRestriction()->isApplicableFor('pre-commit'));
         $this->assertFalse(OfType::getRestriction()->isApplicableFor('pre-push'));
     }
 
-    /**
-     * Tests OfType::isTrue
-     */
     public function testStagedTrue(): void
     {
         $io    = $this->createIOMock();
@@ -44,9 +38,6 @@ class OfTypeTest extends TestCase
         $this->assertTrue($ofType->isTrue($io, $repo));
     }
 
-    /**
-     * Tests OfType::isTrue
-     */
     public function testStagedMultipleTrue(): void
     {
         $io    = $this->createIOMock();
@@ -59,9 +50,6 @@ class OfTypeTest extends TestCase
         $this->assertTrue($ofType->isTrue($io, $repo));
     }
 
-    /**
-     * Tests OfType:isTrue
-     */
     public function testStagedFalse(): void
     {
         $io    = $this->createIOMock();

--- a/tests/unit/Hook/Condition/FileStaged/ThatIsTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/ThatIsTest.php
@@ -20,18 +20,12 @@ class ThatIsTest extends TestCase
     use AppMockery;
     use IOMockery;
 
-    /**
-     * Tests ThatIs::getRestriction
-     */
     public function testPreCommitRestriction(): void
     {
         $this->assertTrue(ThatIs::getRestriction()->isApplicableFor('pre-commit'));
         $this->assertFalse(ThatIs::getRestriction()->isApplicableFor('pre-push'));
     }
 
-    /**
-     * Tests ThatIs::isTrue
-     */
     public function testStagedTrueType(): void
     {
         $io    = $this->createIOMock();
@@ -43,9 +37,6 @@ class ThatIsTest extends TestCase
         $this->assertTrue($thatIs->isTrue($io, $repo));
     }
 
-    /**
-     * Tests ThatIs::isTrue
-     */
     public function testStagedTrueMultipleType(): void
     {
         $io    = $this->createIOMock();
@@ -57,9 +48,6 @@ class ThatIsTest extends TestCase
         $this->assertTrue($thatIs->isTrue($io, $repo));
     }
 
-    /**
-     * Tests ThatIs::isTrue
-     */
     public function testStagedFalseMultipleType(): void
     {
         $io    = $this->createIOMock();
@@ -71,9 +59,6 @@ class ThatIsTest extends TestCase
         $this->assertFalse($thatIs->isTrue($io, $repo));
     }
 
-    /**
-     * Tests ThatIs::isTrue
-     */
     public function testStagedTrueDirectory(): void
     {
         $io    = $this->createIOMock();
@@ -85,9 +70,6 @@ class ThatIsTest extends TestCase
         $this->assertTrue($thatIs->isTrue($io, $repo));
     }
 
-    /**
-     * Tests ThatIs::isTrue
-     */
     public function testStagedFalsePartialDirectory(): void
     {
         $io    = $this->createIOMock();
@@ -99,9 +81,6 @@ class ThatIsTest extends TestCase
         $this->assertFalse($thatIs->isTrue($io, $repo));
     }
 
-    /**
-     * Tests ThatIs::isTrue
-     */
     public function testStagedTrueMultipleDirectory(): void
     {
         $io = $this->createIOMock();
@@ -113,9 +92,6 @@ class ThatIsTest extends TestCase
         $this->assertTrue($thatIs->isTrue($io, $repo));
     }
 
-    /**
-     * Tests ThatIs::isTrue
-     */
     public function testStagedFalseMultipleDirectory(): void
     {
         $io = $this->createIOMock();
@@ -127,9 +103,6 @@ class ThatIsTest extends TestCase
         $this->assertFalse($thatIs->isTrue($io, $repo));
     }
 
-    /**
-     * Tests ThatIs::isTrue
-     */
     public function testStagedFalseDirectoryAndType(): void
     {
         $io    = $this->createIOMock();
@@ -141,9 +114,6 @@ class ThatIsTest extends TestCase
         $this->assertFalse($thatIs->isTrue($io, $repo));
     }
 
-    /**
-     * Tests ThatIs:isTrue
-     */
     public function testStagedFalse(): void
     {
         $io    = $this->createIOMock();

--- a/tests/unit/Hook/Condition/Logic/LogicAndTest.php
+++ b/tests/unit/Hook/Condition/Logic/LogicAndTest.php
@@ -16,15 +16,11 @@ use CaptainHook\App\Hook\Condition;
 use CaptainHook\App\Mockery as AppMockery;
 use PHPUnit\Framework\TestCase;
 
-class LogicalAndTest extends TestCase
+class LogicAndTest extends TestCase
 {
     use IOMockery;
     use AppMockery;
 
-    /**
-     * @covers \CaptainHook\App\Hook\Condition\Logic\LogicAnd::isTrue
-     * @covers \CaptainHook\App\Hook\Condition\Logic\LogicAnd::fromConditionsArray
-     */
     public function testLogicAndReturnsFalseWithOneFailure(): void
     {
         $io         = $this->createIOMock();
@@ -40,10 +36,6 @@ class LogicalAndTest extends TestCase
         $this->assertFalse($condition->isTrue($io, $repository));
     }
 
-    /**
-     * @covers \CaptainHook\App\Hook\Condition\Logic\LogicAnd::isTrue
-     * @covers \CaptainHook\App\Hook\Condition\Logic\LogicAnd::fromConditionsArray
-     */
     public function testLogicAndReturnsTrueWithAllSuccess(): void
     {
         $io         = $this->createIOMock();
@@ -57,9 +49,6 @@ class LogicalAndTest extends TestCase
         $this->assertTrue($condition->isTrue($io, $repository));
     }
 
-    /**
-     * @covers \CaptainHook\App\Hook\Condition\Logic\LogicAnd::fromConditionsArray
-     */
     public function testNamedConstructorIgnoresNonCondition(): void
     {
         $io         = $this->createIOMock();

--- a/tests/unit/Hook/Condition/Logic/LogicOrTest.php
+++ b/tests/unit/Hook/Condition/Logic/LogicOrTest.php
@@ -16,15 +16,11 @@ use CaptainHook\App\Hook\Condition;
 use CaptainHook\App\Mockery as AppMockery;
 use PHPUnit\Framework\TestCase;
 
-class LogicalOrTest extends TestCase
+class LogicOrTest extends TestCase
 {
     use IOMockery;
     use AppMockery;
 
-    /**
-     * @covers \CaptainHook\App\Hook\Condition\Logic\LogicOr::isTrue
-     * @covers \CaptainHook\App\Hook\Condition\Logic\LogicOr::fromConditionsArray
-     */
     public function testLogicOrReturnsTrueWithOneFailure(): void
     {
         $io         = $this->createIOMock();
@@ -40,10 +36,6 @@ class LogicalOrTest extends TestCase
         $this->assertTrue($condition->isTrue($io, $repository));
     }
 
-    /**
-     * @covers \CaptainHook\App\Hook\Condition\Logic\LogicOr::isTrue
-     * @covers \CaptainHook\App\Hook\Condition\Logic\LogicOr::fromConditionsArray
-     */
     public function testLogicOrReturnsFalseWithAllFailing(): void
     {
         $io         = $this->createIOMock();

--- a/tests/unit/Hook/Condition/OnBranchTest.php
+++ b/tests/unit/Hook/Condition/OnBranchTest.php
@@ -20,9 +20,6 @@ class OnBranchTest extends TestCase
     use IOMockery;
     use AppMockery;
 
-    /**
-     * Tests OnBranch::isTrue
-     */
     public function testConditionTrue(): void
     {
         $io           = $this->createIOMock();
@@ -36,9 +33,6 @@ class OnBranchTest extends TestCase
         $this->assertTrue($condition->isTrue($io, $repository));
     }
 
-    /**
-     * Tests OnBranch::isTrue
-     */
     public function testConditionFalse(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Hook/Debug/FailureTest.php
+++ b/tests/unit/Hook/Debug/FailureTest.php
@@ -25,11 +25,6 @@ class FailureTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests Debug::execute
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Debug/SuccessTest.php
+++ b/tests/unit/Hook/Debug/SuccessTest.php
@@ -26,11 +26,6 @@ class SuccessTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests Debug::execute
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
         $config       = $this->createConfigMock(true);
@@ -49,9 +44,6 @@ class SuccessTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Debug::execute
-     */
     public function testExecuteWithoutTags(): void
     {
         $config       = $this->createConfigMock(true);

--- a/tests/unit/Hook/Diff/Action/BlockSecretsTest.php
+++ b/tests/unit/Hook/Diff/Action/BlockSecretsTest.php
@@ -32,9 +32,6 @@ class BlockSecretsTest extends TestCase
     use AppMockery;
     use IOMockery;
 
-    /**
-     * Tests BlockSecrets::getRestriction
-     */
     public function testConstraint(): void
     {
         $this->assertTrue(BlockSecrets::getRestriction()->isApplicableFor('pre-commit'));
@@ -42,11 +39,6 @@ class BlockSecretsTest extends TestCase
         $this->assertFalse(BlockSecrets::getRestriction()->isApplicableFor('post-merge'));
     }
 
-    /**
-     * Tests BlockSecrets::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteSuccess(): void
     {
         $diffOperator = $this->createGitDiffOperator();
@@ -66,11 +58,6 @@ class BlockSecretsTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests BlockSecrets::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteSuccessOnPush(): void
     {
         $diffOperator = $this->createGitDiffOperator();
@@ -92,12 +79,6 @@ class BlockSecretsTest extends TestCase
         $this->assertTrue(true);
     }
 
-
-    /**
-     * Tests BlockSecrets::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteSuccessWithEntropyCheck(): void
     {
         $diffOperator = $this->createGitDiffOperator();
@@ -117,11 +98,6 @@ class BlockSecretsTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests BlockSecrets::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteFailure(): void
     {
         $this->expectException(Exception::class);
@@ -151,11 +127,6 @@ class BlockSecretsTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests BlockSecrets::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteFailureByEntropy(): void
     {
         $this->expectException(Exception::class);
@@ -177,11 +148,6 @@ class BlockSecretsTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests BlockSecrets::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteFailedByEntropyButAllowed(): void
     {
         $options = ['entropyThreshold' => 1, 'allowed' => ['#5ad7\\$\\-9Op0\\-x2§d#']];
@@ -201,11 +167,6 @@ class BlockSecretsTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests BlockSecrets::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteFailedByEntropyBruteForce(): void
     {
         $this->expectException(Exception::class);
@@ -227,11 +188,6 @@ class BlockSecretsTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests BlockSecrets::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteProviderNotFound(): void
     {
         $this->expectException(Exception::class);
@@ -252,11 +208,6 @@ class BlockSecretsTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests BlockSecrets::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteInvalidProvider(): void
     {
         $this->expectException(Exception::class);
@@ -277,9 +228,6 @@ class BlockSecretsTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests BlockSecrets::execute
-     */
     public function testExecuteAllow(): void
     {
         $diffOperator = $this->createGitDiffOperator();

--- a/tests/unit/Hook/File/Action/DoesNotContainRegexTest.php
+++ b/tests/unit/Hook/File/Action/DoesNotContainRegexTest.php
@@ -21,11 +21,6 @@ class DoesNotContainRegexTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests DoesNotContainRegex::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteInvalidOption(): void
     {
         $this->expectException(Exception::class);
@@ -40,11 +35,6 @@ class DoesNotContainRegexTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests DoesNotContainRegex::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteSuccess(): void
     {
         $io     = new NullIO();
@@ -65,11 +55,6 @@ class DoesNotContainRegexTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests DoesNotContainRegex::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteFailure(): void
     {
         $this->expectException(Exception::class);
@@ -90,11 +75,6 @@ class DoesNotContainRegexTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests DoesNotContainRegex::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteMissConfiguration(): void
     {
         $this->expectException(Exception::class);
@@ -115,11 +95,7 @@ class DoesNotContainRegexTest extends TestCase
         $standard = new DoesNotContainRegex();
         $standard->execute($config, $io, $repo, $action);
     }
-    /**
-     * Tests DoesNotContainRegex::execute
-     *
-     * @throws \Exception
-     */
+
     public function testExecuteFailureWithCount(): void
     {
         $this->expectException(Exception::class);
@@ -141,11 +117,6 @@ class DoesNotContainRegexTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests DoesNotContainRegex::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteSuccessWithFileExtension(): void
     {
         $io     = new NullIO();
@@ -174,11 +145,6 @@ class DoesNotContainRegexTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests DoesNotContainRegex::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteFailureWithFileExtension(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/File/Action/ExistsTest.php
+++ b/tests/unit/Hook/File/Action/ExistsTest.php
@@ -21,11 +21,6 @@ class ExistsTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests Exists::execute
-     *
-     * @throws \Exception
-     */
     public function testInvalidConfiguration(): void
     {
         $this->expectException(Exception::class);
@@ -43,11 +38,6 @@ class ExistsTest extends TestCase
         $exists->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests Exists::execute
-     *
-     * @throws \Exception
-     */
     public function testFileExists(): void
     {
         $io     = new NullIO();
@@ -69,11 +59,6 @@ class ExistsTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Exists::execute
-     *
-     * @throws \Exception
-     */
     public function testFileDoesNotExist(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/File/Action/IsEmptyTest.php
+++ b/tests/unit/Hook/File/Action/IsEmptyTest.php
@@ -21,11 +21,6 @@ class IsEmptyTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests IsEmpty::execute
-     *
-     * @throws \Exception
-     */
     public function testInvalidConfiguration(): void
     {
         $this->expectException(Exception::class);
@@ -42,11 +37,6 @@ class IsEmptyTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests IsEmpty::execute
-     *
-     * @throws \Exception
-     */
     public function testCommitEmptyFile(): void
     {
         $io     = new NullIO();
@@ -66,11 +56,6 @@ class IsEmptyTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests IsEmpty::execute
-     *
-     * @throws \Exception
-     */
     public function testCommitUnwatchedEmptyFile(): void
     {
         $io     = new NullIO();
@@ -89,11 +74,6 @@ class IsEmptyTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests IsEmpty::execute
-     *
-     * @throws \Exception
-     */
     public function testFailCommitFileWithContents(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/File/Action/IsNotEmptyTest.php
+++ b/tests/unit/Hook/File/Action/IsNotEmptyTest.php
@@ -23,29 +23,18 @@ class IsNotEmptyTest extends TestCase
     use GitMockery;
     use IOMockery;
 
-    /**
-     * Tests IsNotEmpty::getRestriction
-     */
     public function testRestrictionValid(): void
     {
         $restriction = IsNotEmpty::getRestriction();
         $this->assertTrue($restriction->isApplicableFor('pre-commit'));
     }
 
-    /**
-     * Tests IsNotEmpty::getRestriction
-     */
     public function testRestrictionInvalid(): void
     {
         $restriction = IsNotEmpty::getRestriction();
         $this->assertFalse($restriction->isApplicableFor('pre-push'));
     }
 
-    /**
-     * Tests IsNotEmpty::execute
-     *
-     * @throws \Exception
-     */
     public function testCommitNotEmptyFile(): void
     {
 
@@ -71,11 +60,6 @@ class IsNotEmptyTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests IsNotEmpty::execute
-     *
-     * @throws \Exception
-     */
     public function testConfigWithGlobs(): void
     {
         $io     = $this->createIOMock();
@@ -105,11 +89,6 @@ class IsNotEmptyTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests IsNotEmpty::execute
-     *
-     * @throws \Exception
-     */
     public function testFailCommitEmptyFile(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/File/Action/MaxSizeTest.php
+++ b/tests/unit/Hook/File/Action/MaxSizeTest.php
@@ -18,15 +18,13 @@ use CaptainHook\App\Hooks;
 use CaptainHook\App\Mockery;
 use Exception;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 
 class MaxSizeTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests MaxSite::getRestriction
-     */
     public function testRestrictions(): void
     {
         $restriction = MaxSize::getRestriction();
@@ -35,11 +33,6 @@ class MaxSizeTest extends TestCase
         $this->assertFalse($restriction->isApplicableFor(Hooks::POST_CHECKOUT));
     }
 
-    /**
-     * Tests MaxSize::execute
-     *
-     * @throws \Exception
-     */
     public function testPass(): void
     {
         $io       = new NullIO();
@@ -54,11 +47,6 @@ class MaxSizeTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests MaxSize::execute
-     *
-     * @throws \Exception
-     */
     public function testFail(): void
     {
         $this->expectException(ActionFailed::class);
@@ -75,11 +63,6 @@ class MaxSizeTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests MaxSize::execute
-     *
-     * @throws \Exception
-     */
     public function testInvalidSize(): void
     {
         $this->expectException(Exception::class);
@@ -96,9 +79,7 @@ class MaxSizeTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * @dataProvider toBytesProvider
-     */
+    #[DataProvider('toBytesProvider')]
     public function testToBytes(string $input, int $expected): void
     {
         $maxSize = new MaxSize();
@@ -106,15 +87,15 @@ class MaxSizeTest extends TestCase
         $this->assertSame($expected, $maxSize->toBytes($input));
     }
 
-    public function toBytesProvider(): array
+    public static function toBytesProvider(): array
     {
         return [
-            ['input' => '512B', 'expected' => 512],
-            ['input' => '1K', 'expected' => 1024],
-            ['input' => '5M', 'expected' => 5242880],
-            ['input' => '2G', 'expected' => 2147483648],
-            ['input' => '3T', 'expected' => 3298534883328],
-            ['input' => '4P', 'expected' => 4503599627370496],
+            ['512B', 512],
+            ['1K', 1024],
+            ['5M', 5242880],
+            ['2G', 2147483648],
+            ['3T', 3298534883328],
+            ['4P', 4503599627370496],
         ];
     }
 

--- a/tests/unit/Hook/Message/Action/BeamsTest.php
+++ b/tests/unit/Hook/Message/Action/BeamsTest.php
@@ -22,20 +22,12 @@ class BeamsTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests Beams::getRestriction
-     */
     public function testConstraint(): void
     {
         $this->assertTrue(Beams::getRestriction()->isApplicableFor('commit-msg'));
         $this->assertFalse(Beams::getRestriction()->isApplicableFor('pre-push'));
     }
 
-    /**
-     * Tests Beams::execute
-     *
-     * @throws \Exception
-     */
     public function testExecute(): void
     {
         $io     = new NullIO();
@@ -50,11 +42,6 @@ class BeamsTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Beams::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteImperativeBeginning(): void
     {
         $this->expectException(Exception::class);
@@ -71,11 +58,6 @@ class BeamsTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Beams::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteFail(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Message/Action/CacheOnFailTest.php
+++ b/tests/unit/Hook/Message/Action/CacheOnFailTest.php
@@ -24,9 +24,6 @@ class CacheOnFailTest extends TestCase
     use ConfigMockery;
     use CHMockery;
 
-    /**
-     * Tests CacheOnFail::getEventHandlers
-     */
     public function testExecute(): void
     {
         $io     = new NullIO();
@@ -43,11 +40,6 @@ class CacheOnFailTest extends TestCase
         $this->assertInstanceOf(WriteCacheFile::class, $handlers['onHookFailure'][0]);
     }
 
-    /**
-     * Tests CacheOnFail::getEventHandlers
-     *
-     * @throws \Exception
-     */
     public function testExecuteFail(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Message/Action/InjectIssueKeyFromBranchTest.php
+++ b/tests/unit/Hook/Message/Action/InjectIssueKeyFromBranchTest.php
@@ -26,21 +26,12 @@ class InjectIssueKeyFromBranchTest extends TestCase
     use CHMockery;
     use IOMockery;
 
-
-    /**
-     * Tests Beams::getRestriction
-     */
     public function testConstraint(): void
     {
         $this->assertTrue(InjectIssueKeyFromBranch::getRestriction()->isApplicableFor('prepare-commit-msg'));
         $this->assertFalse(InjectIssueKeyFromBranch::getRestriction()->isApplicableFor('pre-push'));
     }
 
-    /**
-     * Tests InjectIssueKeyFromBranch::execute
-     *
-     * @throws \Exception
-     */
     public function testPrependSubject(): void
     {
         $repo = new RepoMock();
@@ -63,11 +54,6 @@ class InjectIssueKeyFromBranchTest extends TestCase
         $this->assertEquals('ABCD-12345 foo', $repo->getCommitMsg()->getSubject());
     }
 
-    /**
-     * Tests InjectIssueKeyFromBranch::execute
-     *
-     * @throws \Exception
-     */
     public function testAppendSubject(): void
     {
         $repo = new RepoMock();
@@ -90,11 +76,6 @@ class InjectIssueKeyFromBranchTest extends TestCase
         $this->assertEquals('foo ABCD-12345', $repo->getCommitMsg()->getSubject());
     }
 
-    /**
-     * Tests InjectIssueKeyFromBranch::execute
-     *
-     * @throws \Exception
-     */
     public function testAppendBodyWithPrefix(): void
     {
         $repo = new RepoMock();
@@ -121,12 +102,6 @@ class InjectIssueKeyFromBranchTest extends TestCase
         );
     }
 
-
-    /**
-     * Tests InjectIssueKeyFromBranch::execute
-     *
-     * @throws \Exception
-     */
     public function testAppendBodyWithPrefixWithComments(): void
     {
         $repo = new RepoMock();
@@ -159,11 +134,6 @@ class InjectIssueKeyFromBranchTest extends TestCase
         $this->assertStringContainsString('# some comment', $repo->getCommitMsg()->getRawContent());
     }
 
-    /**
-     * Tests InjectIssueKeyFromBranch::execute
-     *
-     * @throws \Exception
-     */
     public function testIgnoreIssueKeyNotFound(): void
     {
         $repo = new RepoMock();
@@ -187,11 +157,6 @@ class InjectIssueKeyFromBranchTest extends TestCase
         $this->assertEquals('bar', $repo->getCommitMsg()->getBody());
     }
 
-    /**
-     * Tests InjectIssueKeyFromBranch::execute
-     *
-     * @throws \Exception
-     */
     public function testFailIssueKeyNotFound(): void
     {
         $this->expectException(ActionFailed::class);
@@ -213,11 +178,6 @@ class InjectIssueKeyFromBranchTest extends TestCase
         $hook->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests InjectIssueKeyFromBranch::execute
-     *
-     * @throws \Exception
-     */
     public function testIssueKeyAlreadyInMSG(): void
     {
         $repo = new RepoMock();
@@ -239,11 +199,6 @@ class InjectIssueKeyFromBranchTest extends TestCase
         $this->assertEquals('ABCD-12345 foo', $repo->getCommitMsg()->getSubject());
     }
 
-    /**
-     * Tests InjectIssueKeyFromBranch::execute
-     *
-     * @throws \Exception
-     */
     public function testSubjectWithPattern(): void
     {
         $repo = new RepoMock();
@@ -267,11 +222,6 @@ class InjectIssueKeyFromBranchTest extends TestCase
         $this->assertEquals('ABCD-12345: foo', $repo->getCommitMsg()->getSubject());
     }
 
-    /**
-     * Tests InjectIssueKeyFromBranch::execute
-     *
-     * @throws \Exception
-     */
     public function testSubjectWithEmptyPattern(): void
     {
         $repo = new RepoMock();

--- a/tests/unit/Hook/Message/Action/PrepareFromFileTest.php
+++ b/tests/unit/Hook/Message/Action/PrepareFromFileTest.php
@@ -27,11 +27,6 @@ class PrepareFromFileTest extends TestCase
     use CHMockery;
     use IOMockery;
 
-    /**
-     * Tests PrepareFromFile::execute
-     *
-     * @throws \Exception
-     */
     public function testExecutePrepareMessageFromFile(): void
     {
         $dummy = new DummyRepo(['msg.cache' => 'prepared from file']);
@@ -49,11 +44,6 @@ class PrepareFromFileTest extends TestCase
         $this->assertEquals('prepared from file', $repo->getCommitMsg()->getRawContent());
     }
 
-    /**
-     * Tests PrepareFromFile::execute
-     *
-     * @throws \Exception
-     */
     public function testExecutePrepareMessageFileDoesNotExist(): void
     {
         $dummy = new DummyRepo();
@@ -71,9 +61,6 @@ class PrepareFromFileTest extends TestCase
         $this->assertEquals('', $repo->getCommitMsg()->getRawContent());
     }
 
-    /**
-     * Tests PrepareFromFile::execute
-     */
     public function testExecutePrepareMessageNoFileOptionFailure(): void
     {
         $this->expectException(ActionFailed::class);

--- a/tests/unit/Hook/Message/Action/PrepareTest.php
+++ b/tests/unit/Hook/Message/Action/PrepareTest.php
@@ -20,11 +20,6 @@ use PHPUnit\Framework\TestCase;
 
 class PrepareTest extends TestCase
 {
-    /**
-     * Tests RegexCheck::execute
-     *
-     * @throws \Exception
-     */
     public function testExecutePrepareMessage(): void
     {
         /** @var NullIO $io */

--- a/tests/unit/Hook/Message/Action/RegexTest.php
+++ b/tests/unit/Hook/Message/Action/RegexTest.php
@@ -22,20 +22,12 @@ class RegexTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests Regex::getRestriction
-     */
     public function testConstraint(): void
     {
         $this->assertTrue(Regex::getRestriction()->isApplicableFor('commit-msg'));
         $this->assertFalse(Regex::getRestriction()->isApplicableFor('pre-push'));
     }
 
-    /**
-     * Tests RegexCheck::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteDefaultSuccess(): void
     {
         $io = $this->createPartialMock(NullIO::class, ['write']);
@@ -53,11 +45,6 @@ class RegexTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests RegexCheck::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteCustomSuccess(): void
     {
         $successMessage = 'Regex matched';
@@ -82,11 +69,6 @@ class RegexTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests RegexCheck::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteInvalidOption(): void
     {
         $this->expectException(Exception::class);
@@ -100,12 +82,6 @@ class RegexTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-
-    /**
-     * Tests RegexCheck::execute
-     *
-     * @throws \Exception
-     */
     public function testMerging(): void
     {
         $io     = new NullIO();
@@ -120,11 +96,6 @@ class RegexTest extends TestCase
         $this->assertTrue(true, 'Since we are merging nothing should happen');
     }
 
-    /**
-     * Tests RegexCheck::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteNoMatchCustomErrorMessage(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Message/Action/RulesTest.php
+++ b/tests/unit/Hook/Message/Action/RulesTest.php
@@ -24,11 +24,6 @@ class RulesTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests Rulebook::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteEmptyRules(): void
     {
         $io     = new NullIO();
@@ -43,11 +38,6 @@ class RulesTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Rulebook::execute
-     *
-     * @throws \Exception
-     */
     public function testNoValidationOnMerging(): void
     {
         $io     = new NullIO();
@@ -62,9 +52,6 @@ class RulesTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Rulebook::execute
-     */
     public function testExecuteClassNotFound(): void
     {
         $this->expectException(Exception::class);
@@ -78,11 +65,6 @@ class RulesTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests Rulebook::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteInvalidClass(): void
     {
         $this->expectException(Exception::class);
@@ -96,11 +78,6 @@ class RulesTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests Rulebook::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteValidRule(): void
     {
         $io     = new NullIO();
@@ -115,11 +92,6 @@ class RulesTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Rulebook::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteValidRuleWithArguments(): void
     {
         $io     = new NullIO();
@@ -139,11 +111,6 @@ class RulesTest extends TestCase
         }
     }
 
-    /**
-     * Tests Rulebook::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteLimitSubjectLengthRuleWithUnicode(): void
     {
         $io     = new NullIO();
@@ -163,11 +130,6 @@ class RulesTest extends TestCase
         }
     }
 
-    /**
-     * Tests Rule::execute
-     *
-     * @throws \Exception
-     */
     public function testNoRule(): void
     {
         $this->expectException(Exception::class);
@@ -182,11 +144,6 @@ class RulesTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests Rule::execute
-     *
-     * @throws \Exception
-     */
     public function testInvalidComplexRule(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Message/EventHandler/WriteCacheFileTest.php
+++ b/tests/unit/Hook/Message/EventHandler/WriteCacheFileTest.php
@@ -24,9 +24,6 @@ class WriteCacheFileTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests WriteCacheFile::handle
-     */
     public function testHandle(): void
     {
         $dummy   = new DummyRepo();

--- a/tests/unit/Hook/Message/Rule/BlacklistTest.php
+++ b/tests/unit/Hook/Message/Rule/BlacklistTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class BlacklistTest extends TestCase
 {
-    /**
-     * Tests Blacklist::pass
-     */
     public function testCaseInsensitiveHit(): void
     {
         $msg  = new CommitMessage('Foo bar baz' . PHP_EOL . PHP_EOL . 'Some Body text that is longer');
@@ -29,9 +26,6 @@ class BlacklistTest extends TestCase
         $this->assertFalse($list->pass($msg));
     }
 
-    /**
-     * Tests Blacklist::pass
-     */
     public function testCaseSensitiveMiss(): void
     {
         $msg  = new CommitMessage('Foo bar baz' . PHP_EOL . PHP_EOL . 'Some Body text that is longer');

--- a/tests/unit/Hook/Message/Rule/CapitalizeSubjectTest.php
+++ b/tests/unit/Hook/Message/Rule/CapitalizeSubjectTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class CapitalizeSubjectTest extends TestCase
 {
-    /**
-     * Tests CapitalizeSubject::pass
-     */
     public function testPassSuccess(): void
     {
         $msg  = new CommitMessage('Foo');
@@ -27,9 +24,6 @@ class CapitalizeSubjectTest extends TestCase
         $this->assertTrue($rule->pass($msg));
     }
 
-    /**
-     * Tests CapitalizeSubject::pass
-     */
     public function testPassFail(): void
     {
         $msg  = new CommitMessage('foo');
@@ -38,9 +32,6 @@ class CapitalizeSubjectTest extends TestCase
         $this->assertFalse($rule->pass($msg));
     }
 
-    /**
-     * Tests CapitalizeSubject::pass
-     */
     public function testPassFailOnEmptyMessage(): void
     {
         $msg  = new CommitMessage('');

--- a/tests/unit/Hook/Message/Rule/LimitBodyLineLengthTest.php
+++ b/tests/unit/Hook/Message/Rule/LimitBodyLineLengthTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class LimitBodyLineLengthTest extends TestCase
 {
-    /**
-     * Tests LimitBodyLineLength::pass
-     */
     public function testPassSuccess(): void
     {
         $msg  = new CommitMessage('Foo' . PHP_EOL . PHP_EOL . 'Bar');
@@ -27,9 +24,6 @@ class LimitBodyLineLengthTest extends TestCase
         $this->assertTrue($rule->pass($msg));
     }
 
-    /**
-     * Tests LimitBodyLineLength::pass
-     */
     public function testPassFail(): void
     {
         $msg  = new CommitMessage('Foo' . PHP_EOL . PHP_EOL . 'Bar Baz Fiz Baz');
@@ -38,9 +32,6 @@ class LimitBodyLineLengthTest extends TestCase
         $this->assertFalse($rule->pass($msg));
     }
 
-    /**
-     * Tests LimitBodyLineLength::pass
-     */
     public function testPassFailOnAnyLine(): void
     {
         $msg  = new CommitMessage('Foo' . PHP_EOL . PHP_EOL . 'Fooish' . PHP_EOL . 'Bar Baz Fiz Baz');

--- a/tests/unit/Hook/Message/Rule/LimitSubjectLengthTest.php
+++ b/tests/unit/Hook/Message/Rule/LimitSubjectLengthTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class LimitSubjectLengthTest extends TestCase
 {
-    /**
-     * Tests LimitSubjectLength::pass
-     */
     public function testPassSuccess(): void
     {
         $msg  = new CommitMessage('Foo Bar');
@@ -27,9 +24,6 @@ class LimitSubjectLengthTest extends TestCase
         $this->assertTrue($rule->pass($msg));
     }
 
-    /**
-     * Tests LimitSubjectLength::pass
-     */
     public function testPassFail(): void
     {
         $msg  = new CommitMessage('Foo Bar Baz Fiz Baz');

--- a/tests/unit/Hook/Message/Rule/MsgNotEmptyTest.php
+++ b/tests/unit/Hook/Message/Rule/MsgNotEmptyTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class MsgNotEmptyTest extends TestCase
 {
-    /**
-     * Tests MsgNotEmpty::pass
-     */
     public function testPassSuccess(): void
     {
         $msg  = new CommitMessage('Foo bar');
@@ -27,9 +24,6 @@ class MsgNotEmptyTest extends TestCase
         $this->assertTrue($rule->pass($msg));
     }
 
-    /**
-     * Tests MsgNotEmpty::pass
-     */
     public function testPassFail(): void
     {
         $msg  = new CommitMessage('');

--- a/tests/unit/Hook/Message/Rule/NoPeriodOnSubjectEndTest.php
+++ b/tests/unit/Hook/Message/Rule/NoPeriodOnSubjectEndTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class NoPeriodOnSubjectEndTest extends TestCase
 {
-    /**
-     * Tests NoPeriodOnSubjectEnd::pass
-     */
     public function testPassSuccess(): void
     {
         $msg  = new CommitMessage('Foo bar');
@@ -27,9 +24,6 @@ class NoPeriodOnSubjectEndTest extends TestCase
         $this->assertTrue($rule->pass($msg));
     }
 
-    /**
-     * Tests NoPeriodOnSubjectEnd::pass
-     */
     public function testPassFail(): void
     {
         $msg  = new CommitMessage('Foo bar.');

--- a/tests/unit/Hook/Message/Rule/SeparateSubjectFromBodyWithBlankLineTest.php
+++ b/tests/unit/Hook/Message/Rule/SeparateSubjectFromBodyWithBlankLineTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class SeparateSubjectFromBodyWithBlankLineTest extends TestCase
 {
-    /**
-     * Tests SeparateSubjectFromBodyWithBlankLine::pass
-     */
     public function testPassSuccessOnSubjectOnly(): void
     {
         $msg  = new CommitMessage('Foo bar');
@@ -27,9 +24,6 @@ class SeparateSubjectFromBodyWithBlankLineTest extends TestCase
         $this->assertTrue($rule->pass($msg));
     }
 
-    /**
-     * Tests SeparateSubjectFromBodyWithBlankLine::pass
-     */
     public function testPassSuccessWithBody(): void
     {
         $msg  = new CommitMessage('Foo bar' . PHP_EOL . PHP_EOL . 'Foo Bar Baz.');
@@ -38,9 +32,6 @@ class SeparateSubjectFromBodyWithBlankLineTest extends TestCase
         $this->assertTrue($rule->pass($msg));
     }
 
-    /**
-     * Tests SeparateSubjectFromBodyWithBlankLine::pass
-     */
     public function testPassFailNoEmptyLine(): void
     {
         $msg  = new CommitMessage('Foo bar' . PHP_EOL . 'Foo Bar Baz.');

--- a/tests/unit/Hook/Message/Rule/UseImperativeMoodTest.php
+++ b/tests/unit/Hook/Message/Rule/UseImperativeMoodTest.php
@@ -11,20 +11,18 @@
 
 namespace CaptainHook\App\Hook\Message\Rule;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SebastianFeldmann\Git\CommitMessage;
 use PHPUnit\Framework\TestCase;
 
 class UseImperativeMoodTest extends TestCase
 {
     /**
-     * Tests UseImperativeMood::pass
-     *
-     * @dataProvider passProvider
-     *
      * @param string $string
      * @param bool   $begin
      * @param bool   $expectedResult
      */
+    #[DataProvider('passProvider')]
     public function testPass(string $string, bool $begin, bool $expectedResult): void
     {
         $msg  = new CommitMessage($string);
@@ -32,12 +30,7 @@ class UseImperativeMoodTest extends TestCase
         $this->assertSame($expectedResult, $rule->pass($msg));
     }
 
-    /**
-     * The testPass data provider
-     *
-     * @return array
-     */
-    public function passProvider(): array
+    public static function passProvider(): array
     {
         return [
             ['foo bar baz', true, true],

--- a/tests/unit/Hook/Message/RuleBook/RuleSetTest.php
+++ b/tests/unit/Hook/Message/RuleBook/RuleSetTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class RuleSetTest extends TestCase
 {
-    /**
-     * Tests RuleSet::beams
-     */
     public function testRuleSetBeams(): void
     {
         $msg   = new CommitMessage('Foo bar baz' . PHP_EOL . PHP_EOL . 'This is a longer body line.');

--- a/tests/unit/Hook/Message/RuleBookTest.php
+++ b/tests/unit/Hook/Message/RuleBookTest.php
@@ -19,9 +19,6 @@ use PHPUnit\Framework\TestCase;
 
 class RuleBookTest extends TestCase
 {
-    /**
-     * Tests RuleBook::validate
-     */
     public function testValidOnEmptyRuleList(): void
     {
         $msg = new CommitMessage('Foo');
@@ -31,9 +28,6 @@ class RuleBookTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests RuleBook::setRules
-     */
     public function testSetRulesValid(): void
     {
         $msg = new CommitMessage('Foo');
@@ -44,9 +38,6 @@ class RuleBookTest extends TestCase
         $this->assertEquals([], $problems);
     }
 
-    /**
-     * Tests RuleBook::setRules
-     */
     public function testSetRulesInvalid(): void
     {
         $msg = new CommitMessage('');
@@ -56,9 +47,6 @@ class RuleBookTest extends TestCase
         $this->assertCount(1, $problems);
     }
 
-    /**
-     * Tests RuleBook::setRules
-     */
     public function testAddRuleInvalid(): void
     {
         $msg = new CommitMessage('foo bar baz');
@@ -70,9 +58,6 @@ class RuleBookTest extends TestCase
         $this->assertCount(1, $problems);
     }
 
-    /**
-     * Tests RuleBook::setRules
-     */
     public function testAddRuleInvalidMultiLineProblem(): void
     {
         $msg = new CommitMessage('fixed bar baz');

--- a/tests/unit/Hook/Notify/Action/IntegrateBeforePushTest.php
+++ b/tests/unit/Hook/Notify/Action/IntegrateBeforePushTest.php
@@ -35,9 +35,6 @@ class IntegrateBeforePushTest extends TestCase
     use ConfigMockery;
     use IOMockery;
 
-    /**
-     * Tests IntegrateBeforePush::getRestriction
-     */
     public function testRestrictions(): void
     {
         $restriction = IntegrateBeforePush::getRestriction();
@@ -46,9 +43,6 @@ class IntegrateBeforePushTest extends TestCase
         $this->assertFalse($restriction->isApplicableFor(Hooks::PRE_COMMIT));
     }
 
-    /**
-     * Tests: IntegrateBeforePush::execute
-     */
     public function testBlockPush(): void
     {
         $io           = $this->createIOMock();
@@ -81,9 +75,6 @@ class IntegrateBeforePushTest extends TestCase
         $action->execute($config, $io, $repository, $actionConfig);
     }
 
-    /**
-     * Tests: IntegrateBeforePush::execute
-     */
     public function testNoTrigger(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Hook/Notify/Action/NotifyTest.php
+++ b/tests/unit/Hook/Notify/Action/NotifyTest.php
@@ -25,18 +25,12 @@ class NotifyTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests Notify::getRestriction
-     */
     public function testConstraint(): void
     {
         $this->assertTrue(Notify::getRestriction()->isApplicableFor('post-checkout'));
         $this->assertFalse(Notify::getRestriction()->isApplicableFor('commit-msg'));
     }
 
-    /**
-     * Tests Notify::execute
-     */
     public function testExecuteWithNotifications()
     {
         $io      = $this->createIOMock();
@@ -60,9 +54,6 @@ class NotifyTest extends TestCase
         $notify->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests Notify::execute
-     */
     public function testExecuteWithoutNotifications()
     {
         $io      = $this->createIOMock();
@@ -86,9 +77,6 @@ class NotifyTest extends TestCase
         $notify->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests Notify::execute
-     */
     public function testExecuteWithCustomPrefix()
     {
         $io      = $this->createIOMock();

--- a/tests/unit/Hook/Notify/ExtractorTest.php
+++ b/tests/unit/Hook/Notify/ExtractorTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class ExtractorTest extends TestCase
 {
-    /**
-     * Tests Extractor::extractNotification
-     */
     public function testExtractMultilineNotification()
     {
         $message = 'Foo' . PHP_EOL . 'git-notify: FIZ' . PHP_EOL . 'baz' . PHP_EOL . 'biz';
@@ -26,9 +23,6 @@ class ExtractorTest extends TestCase
         $this->assertEquals(3, $notification->length());
     }
 
-    /**
-     * Tests Extractor::extractNotification
-     */
     public function testExtractNotificationWithoutPrefix()
     {
         $message = 'Foo' . PHP_EOL . 'bar';

--- a/tests/unit/Hook/Notify/NotificationTest.php
+++ b/tests/unit/Hook/Notify/NotificationTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class NotificationTest extends TestCase
 {
-    /**
-     * Tests Notification::banner
-     */
     public function testBanner()
     {
         $banner = PHP_EOL

--- a/tests/unit/Hook/PHP/Action/LintingTest.php
+++ b/tests/unit/Hook/PHP/Action/LintingTest.php
@@ -21,11 +21,6 @@ class LintingTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests Linter::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteValidPHP(): void
     {
         $io       = new NullIO();
@@ -42,11 +37,6 @@ class LintingTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests Linter::execute
-     *
-     * @throws \Exception
-     */
     public function testExecuteInvalidPHP(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/PHP/Action/TestCoverageTest.php
+++ b/tests/unit/Hook/PHP/Action/TestCoverageTest.php
@@ -21,11 +21,6 @@ class TestCoverageTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests TestCoverage::execute
-     *
-     * @throws \Exception
-     */
     public function testCoverageViaCloverXML(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -45,11 +40,6 @@ class TestCoverageTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests TestCoverage::execute
-     *
-     * @throws \Exception
-     */
     public function testCoverageLow(): void
     {
         $this->expectException(Exception::class);
@@ -68,11 +58,6 @@ class TestCoverageTest extends TestCase
         $standard->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests TestCoverage::execute
-     *
-     * @throws \Exception
-     */
     public function testCoverageViaPHPUnit(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {

--- a/tests/unit/Hook/PHP/CoverageResolver/CloverXmlTest.php
+++ b/tests/unit/Hook/PHP/CoverageResolver/CloverXmlTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class CloverXMLTest extends TestCase
 {
-    /**
-     * Tests CloverXML::getCoverage
-     */
     public function testValid(): void
     {
         $resolver = new CloverXML(CH_PATH_FILES . '/coverage/valid.xml');
@@ -27,9 +24,6 @@ class CloverXMLTest extends TestCase
         $this->assertEquals(95, $coverage);
     }
 
-    /**
-     * Tests CloverXML::getCoverage
-     */
     public function testValid100Percent(): void
     {
         $resolver = new CloverXML(CH_PATH_FILES . '/coverage/valid-100.xml');
@@ -38,9 +32,6 @@ class CloverXMLTest extends TestCase
         $this->assertEquals(100, $coverage);
     }
 
-    /**
-     * Tests CloverXML::__construct
-     */
     public function testFileNotFound(): void
     {
         $this->expectException(Exception::class);
@@ -49,9 +40,6 @@ class CloverXMLTest extends TestCase
         $this->assertNull($resolver);
     }
 
-    /**
-     * Tests CloverXML::__construct
-     */
     public function testCrapMetrics(): void
     {
         $this->expectException(Exception::class);
@@ -60,9 +48,6 @@ class CloverXMLTest extends TestCase
         $resolver->getCoverage();
     }
 
-    /**
-     * Tests CloverXML::__construct
-     */
     public function testInvalidXML(): void
     {
         $this->expectException(Exception::class);
@@ -71,9 +56,6 @@ class CloverXMLTest extends TestCase
         $this->assertNull($resolver);
     }
 
-    /**
-     * Tests CloverXML::__construct
-     */
     public function testInvalidMetrics(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/PHP/CoverageResolver/PHPUnitTest.php
+++ b/tests/unit/Hook/PHP/CoverageResolver/PHPUnitTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class PHPUnitTest extends TestCase
 {
-    /**
-     * Tests PHPUnit::getCoverage
-     */
     public function testValid(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -31,9 +28,6 @@ class PHPUnitTest extends TestCase
         $this->assertEquals(95, $coverage);
     }
 
-    /**
-     * Tests PHPUnit::getCoverage
-     */
     public function testPHPUnitError(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/RestrictionTest.php
+++ b/tests/unit/Hook/RestrictionTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class RestrictionTest extends TestCase
 {
-    /**
-     * Tests Restriction::isApplicable
-     */
     public function testIsApplicableFromArray(): void
     {
         $restriction = Restriction::fromArray(['pre-commit', 'pre-push']);
@@ -27,9 +24,6 @@ class RestrictionTest extends TestCase
         $this->assertFalse($restriction->isApplicableFor('post-push'));
     }
 
-    /**
-     * Tests Restriction::isApplicable
-     */
     public function testIsApplicableFromString(): void
     {
         $restriction = Restriction::fromString('pre-commit');
@@ -38,9 +32,6 @@ class RestrictionTest extends TestCase
         $this->assertFalse($restriction->isApplicableFor('post-push'));
     }
 
-    /**
-     * Tests Restriction::isApplicable
-     */
     public function testIsApplicableEmpty(): void
     {
         $restriction = Restriction::empty();
@@ -49,9 +40,6 @@ class RestrictionTest extends TestCase
         $this->assertFalse($restriction->isApplicableFor('post-push'));
     }
 
-    /**
-     * Tests Restriction::isApplicable
-     */
     public function testIsApplicableEmptyAddingRestrictions(): void
     {
         $restriction = Restriction::empty()->with('pre-commit');
@@ -60,9 +48,6 @@ class RestrictionTest extends TestCase
         $this->assertFalse($restriction->isApplicableFor('post-push'));
     }
 
-    /**
-     * Tests Restriction::isApplicable
-     */
     public function testIsApplicableWithAlreadyApplicableRestrictions(): void
     {
         $restriction = Restriction::fromString('pre-commit')->with('pre-commit');
@@ -71,9 +56,6 @@ class RestrictionTest extends TestCase
         $this->assertFalse($restriction->isApplicableFor('post-push'));
     }
 
-    /**
-     * Tests Restriction::isApplicable
-     */
     public function testIsApplicableWithVirtualHook(): void
     {
         $restriction = Restriction::fromString('post-change');

--- a/tests/unit/Hook/Template/BuilderTest.php
+++ b/tests/unit/Hook/Template/BuilderTest.php
@@ -25,9 +25,6 @@ class BuilderTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests Builder::build
-     */
     public function testBuildDockerTemplate(): void
     {
         $repo = new DummyRepo(
@@ -60,9 +57,6 @@ class BuilderTest extends TestCase
         $this->assertStringContainsString('--bootstrap=vendor/autoload.php', $code);
     }
 
-    /**
-     * Tests Builder::build
-     */
     public function testBuildDockerTemplateWithoutBootstrapFromPHAR(): void
     {
         $repo = new DummyRepo(
@@ -94,9 +88,6 @@ class BuilderTest extends TestCase
         $this->assertStringNotContainsString('--bootstrap=', $code);
     }
 
-    /**
-     * Tests Builder::build
-     */
     public function testBuildDockerTemplateWithBinaryOutsideRepo(): void
     {
         $repo = new DummyRepo(
@@ -126,9 +117,6 @@ class BuilderTest extends TestCase
         $this->assertStringContainsString($executable, $code);
     }
 
-    /**
-     * Tests Builder::build
-     */
     public function testBuildLocalTemplateWithoutBootstrapFromPHAR(): void
     {
         $resolver   = $this->createResolverMock(CH_PATH_FILES . '/bin/captainhook', true);
@@ -146,9 +134,6 @@ class BuilderTest extends TestCase
         $this->assertStringNotContainsString('--bootstrap=', $code);
     }
 
-    /**
-     * Tests Builder::build
-     */
     public function testBuildLocalTemplate(): void
     {
         $resolver   = $this->createResolverMock(CH_PATH_FILES . '/bin/captainhook', false);
@@ -166,9 +151,6 @@ class BuilderTest extends TestCase
         $this->assertStringContainsString('$captainHook->run', $code);
     }
 
-    /**
-     * Tests Builder::build
-     */
     public function testBuildWSLTemplate(): void
     {
         $resolver   = $this->createResolverMock(CH_PATH_FILES . '/bin/captainhook', false);
@@ -186,9 +168,6 @@ class BuilderTest extends TestCase
         $this->assertStringContainsString('wsl.exe', $code);
     }
 
-    /**
-     * Tests Builder::build
-     */
     public function testBuildBootstrapNotFound(): void
     {
         $this->expectException(Exception::class);
@@ -208,9 +187,6 @@ class BuilderTest extends TestCase
         $this->assertStringContainsString('$captainHook->run', $code);
     }
 
-    /**
-     * Tests Builder::build
-     */
     public function testBuildInvalidVendor(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Template/DockerTest.php
+++ b/tests/unit/Hook/Template/DockerTest.php
@@ -12,6 +12,7 @@
 namespace CaptainHook\App\Hook\Template;
 
 use CaptainHook\App\Config\Run;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use CaptainHook\App\Config\Mockery as ConfigMockery;
 
@@ -19,9 +20,6 @@ class DockerTest extends TestCase
 {
     use ConfigMockery;
 
-    /**
-     * Tests Docker::getCode
-     */
     public function testTemplateCaptainHookDevelopment(): void
     {
         $repo       = realpath(CH_PATH_FILES . '/template-ch');
@@ -42,9 +40,6 @@ class DockerTest extends TestCase
         $this->assertStringContainsString('./bin/captainhook', $code);
     }
 
-    /**
-     * Tests Docker::getCode
-     */
     public function testTemplateCaptainHookAsLibrary(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -64,9 +59,6 @@ class DockerTest extends TestCase
         $this->assertStringContainsString('./vendor/bin/captainhook', $code);
     }
 
-    /**
-     * Tests Docker::getCode
-     */
     public function testTemplateCustomPath(): void
     {
         $repo       = realpath(CH_PATH_FILES . '/template-ch');
@@ -90,11 +82,7 @@ class DockerTest extends TestCase
         $this->assertStringContainsString('bootstrap=vendor/autoload.php', $code);
     }
 
-    /**
-     * Tests Docker::getCode
-     *
-     * @dataProvider replacementPossibilitiesWithoutGitMapping
-     */
+    #[DataProvider('replacementPossibilitiesWithoutGitMapping')]
     public function testDockerCommandOptimizationWithoutGitMapping(string $exec, string $expected, string $msg): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -117,12 +105,7 @@ class DockerTest extends TestCase
         $this->assertStringContainsString('/usr/local/bin/captainhook', $code);
     }
 
-    /**
-     * The testDockerCommandOptimization data provider
-     *
-     * @return array
-     */
-    public function replacementPossibilitiesWithoutGitMapping(): array
+    public static function replacementPossibilitiesWithoutGitMapping(): array
     {
         return [
             ['cap-container', '-i cap-container', 'none'],
@@ -137,11 +120,7 @@ class DockerTest extends TestCase
         ];
     }
 
-    /**
-     * Tests Docker::getCode
-     *
-     * @dataProvider replacementPossibilitiesWithGitMapping
-     */
+    #[DataProvider('replacementPossibilitiesWithGitMapping')]
     public function testDockerCommandOptimizationWithGitMapping(string $exec, string $expected, string $msg): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -167,12 +146,7 @@ class DockerTest extends TestCase
         $this->assertStringNotContainsString('docker exec' . $expected, $codePush, $msg);
     }
 
-    /**
-     * The testDockerCommandOptimization data provider
-     *
-     * @return array
-     */
-    public function replacementPossibilitiesWithGitMapping(): array
+    public static function replacementPossibilitiesWithGitMapping(): array
     {
         $env = ' -e GIT_INDEX_FILE="/docker/.git/$(basename $GIT_INDEX_FILE)"';
         return [

--- a/tests/unit/Hook/Template/InspectorTest.php
+++ b/tests/unit/Hook/Template/InspectorTest.php
@@ -23,9 +23,6 @@ class InspectorTest extends TestCase
     use IOMockery;
     use AppMockery;
 
-    /**
-     * Tests Inspector::inspect
-     */
     public function testInspectValid(): void
     {
         $io    = $this->createIOMock();
@@ -39,9 +36,6 @@ class InspectorTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Inspector::inspect
-     */
     public function testInspectInvalid(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/Template/Local/PHPTest.php
+++ b/tests/unit/Hook/Template/Local/PHPTest.php
@@ -19,9 +19,6 @@ class PHPTest extends TestCase
 {
     use ConfigMockery;
 
-    /**
-     * Tests PHP::getCode
-     */
     public function testSrcTemplate(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -39,9 +36,6 @@ class PHPTest extends TestCase
         $this->assertStringContainsString('$captainHook->run(', $code);
     }
 
-    /**
-     * Tests PHP::getCode
-     */
     public function testSrcStdInHook(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -59,9 +53,6 @@ class PHPTest extends TestCase
         $this->assertStringContainsString('$captainHook->run(', $code);
     }
 
-    /**
-     * Tests PHP::getCode
-     */
     public function testSrcTemplateExtExecutable(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -80,9 +71,6 @@ class PHPTest extends TestCase
         $this->assertStringContainsString('$captainHook->run(', $code);
     }
 
-    /**
-     * Tests PHP::getCode
-     */
     public function testPharAbsoluteExecutablePath(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -101,9 +89,6 @@ class PHPTest extends TestCase
         $this->assertStringContainsString('/usr/local/bin/captainhook', $code);
     }
 
-    /**
-     * Tests PHP::getCode
-     */
     public function testPharTemplate(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -122,9 +107,6 @@ class PHPTest extends TestCase
         $this->assertStringContainsString('tools/captainhook.phar', $code);
     }
 
-    /**
-     * Tests PHP::getCode
-     */
     public function testPharStdIn(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);

--- a/tests/unit/Hook/Template/Local/ShellTest.php
+++ b/tests/unit/Hook/Template/Local/ShellTest.php
@@ -20,9 +20,6 @@ class ShellTest extends TestCase
 {
     use ConfigMockery;
 
-    /**
-     * Tests Shell::getCode
-     */
     public function testTemplate(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -43,9 +40,6 @@ class ShellTest extends TestCase
         $this->assertStringContainsString('vendor/bin/captainhook $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests Shell::getCode
-     */
     public function testTemplateWithoutBootstrap(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -65,9 +59,6 @@ class ShellTest extends TestCase
         $this->assertStringContainsString('vendor/bin/captainhook $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests Shell::getCode
-     */
     public function testTemplateWithDefinedPHP(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -88,9 +79,6 @@ class ShellTest extends TestCase
         $this->assertStringContainsString('vendor/bin/captainhook $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests Shell::getCode
-     */
     public function testTemplateWithDefinedPHPAndRunPath(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -113,9 +101,6 @@ class ShellTest extends TestCase
         $this->assertStringContainsString('tools/captainhook.phar $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests Shell::getCode
-     */
     public function testTemplateExtExecutable(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -136,9 +121,6 @@ class ShellTest extends TestCase
         $this->assertStringContainsString('/usr/local/bin/captainhook $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests Shell::getCode
-     */
     public function testTemplateExtExecutableWithDefinedPHP(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -160,9 +142,6 @@ class ShellTest extends TestCase
         $this->assertStringContainsString('/usr/local/bin/captainhook $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests Shell::getCode
-     */
     public function testTemplateExtExecutableWithUserInput(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -183,11 +162,6 @@ class ShellTest extends TestCase
         $this->assertStringContainsString($this->getTtyRedirectionLines(), $code);
     }
 
-    /**
-     * Returns the expected TTY redirection lines
-     *
-     * @return string
-     */
     private function getTtyRedirectionLines(): string
     {
         return <<<'EOD'

--- a/tests/unit/Hook/Template/Local/WSLTest.php
+++ b/tests/unit/Hook/Template/Local/WSLTest.php
@@ -20,9 +20,6 @@ class WSLTest extends ShellTest
 {
     use ConfigMockery;
 
-    /**
-     * Tests WSL::getCode
-     */
     public function testTemplate(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -43,9 +40,6 @@ class WSLTest extends ShellTest
         $this->assertStringContainsString('wsl.exe vendor/bin/captainhook $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests WSL::getCode
-     */
     public function testTemplateWithDefinedPHP(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -66,9 +60,6 @@ class WSLTest extends ShellTest
         $this->assertStringContainsString('wsl.exe /usr/bin/php7.4 vendor/bin/captainhook $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests WSL::getCode
-     */
     public function testTemplateWithDefinedPHPAndRunPath(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -91,9 +82,6 @@ class WSLTest extends ShellTest
         $this->assertStringContainsString('wsl.exe /usr/bin/php7.4 tools/captainhook.phar $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests WSL::getCode
-     */
     public function testTemplateExtExecutable(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -114,9 +102,6 @@ class WSLTest extends ShellTest
         $this->assertStringContainsString('wsl.exe /usr/local/bin/captainhook $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests WSL::getCode
-     */
     public function testTemplateExtExecutableWithDefinedPHP(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);
@@ -138,9 +123,6 @@ class WSLTest extends ShellTest
         $this->assertStringContainsString('wsl.exe /usr/bin/php7.4 /usr/local/bin/captainhook $INTERACTIVE', $code);
     }
 
-    /**
-     * Tests WSL::getCode
-     */
     public function testTemplateExtExecutableWithUserInput(): void
     {
         $pathInfo = $this->createMock(PathInfo::class);

--- a/tests/unit/Hook/UserInput/AskConfirmationTest.php
+++ b/tests/unit/Hook/UserInput/AskConfirmationTest.php
@@ -25,9 +25,6 @@ class AskConfirmationTest extends TestCase
     use ConfigMockery;
     use CHMockery;
 
-    /**
-     * Tests CacheOnFail::getEventHandlers
-     */
     public function testExecute(): void
     {
         $io     = new NullIO();

--- a/tests/unit/Hook/UserInput/EventHandler/AskConfirmationTest.php
+++ b/tests/unit/Hook/UserInput/EventHandler/AskConfirmationTest.php
@@ -25,9 +25,6 @@ class AskConfirmationTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests AskConfirmation::handle
-     */
     public function testHandleYes(): void
     {
         $dummy   = new DummyRepo();
@@ -42,9 +39,6 @@ class AskConfirmationTest extends TestCase
         $handler->handle($event);
     }
 
-    /**
-     * Tests AskConfirmation::handle
-     */
     public function testHandleNo(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Hook/UtilTest.php
+++ b/tests/unit/Hook/UtilTest.php
@@ -11,6 +11,7 @@
 
 namespace CaptainHook\App\Hook;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use CaptainHook\App\Console\IO\Mockery;
@@ -19,9 +20,6 @@ class UtilTest extends TestCase
 {
     use Mockery;
 
-    /**
-     * Tests Util::isValid
-     */
     public function testIsValid(): void
     {
         $this->assertTrue(Util::isValid('pre-commit'));
@@ -30,9 +28,6 @@ class UtilTest extends TestCase
         $this->assertFalse(Util::isValid('foo'));
     }
 
-    /**
-     * Tests Util::isInstallable
-     */
     public function testIsInstallable(): void
     {
         $this->assertTrue(Util::isInstallable('pre-commit'));
@@ -41,9 +36,6 @@ class UtilTest extends TestCase
         $this->assertFalse(Util::isInstallable('post-change'));
     }
 
-    /**
-     * Tests Util::getValidHooks
-     */
     public function testGetValidHooks(): void
     {
         $this->assertArrayHasKey('pre-commit', Util::getValidHooks());
@@ -51,14 +43,7 @@ class UtilTest extends TestCase
         $this->assertArrayHasKey('commit-msg', Util::getValidHooks());
     }
 
-    /**
-     * Tests Util::getHookCommand
-     *
-     * @dataProvider providerValidCommands
-     *
-     * @param string $class
-     * @param string $hook
-     */
+    #[DataProvider('providerValidCommands')]
     public function testGetHookCommandValid(string $class, string $hook): void
     {
         $this->assertEquals($class, Util::getHookCommand($hook));
@@ -67,10 +52,7 @@ class UtilTest extends TestCase
         $this->assertEquals('PrePush', Util::getHookCommand('pre-push'));
     }
 
-    /**
-     * @return array
-     */
-    public function providerValidCommands(): array
+    public static function providerValidCommands(): array
     {
         return [
             ['CommitMsg', 'commit-msg'],
@@ -80,11 +62,7 @@ class UtilTest extends TestCase
         ];
     }
 
-    /**
-     * Tests Util::getHookCommand
-     *
-     * @dataProvider providerInvalidCommands
-     */
+    #[DataProvider('providerInvalidCommands')]
     public function testGetHookCommandInvalid(string $hook): void
     {
         $this->expectException(RuntimeException::class);
@@ -92,10 +70,7 @@ class UtilTest extends TestCase
         $this->assertEquals('', Util::getHookCommand($hook));
     }
 
-    /**
-     * @return array
-     */
-    public function providerInvalidCommands(): array
+    public static function providerInvalidCommands(): array
     {
         return [
             [''],
@@ -103,9 +78,6 @@ class UtilTest extends TestCase
         ];
     }
 
-    /**
-     * Tests Util::getHooks
-     */
     public function testGetHooks(): void
     {
         $this->assertContains('pre-commit', Util::getHooks());
@@ -113,9 +85,6 @@ class UtilTest extends TestCase
         $this->assertContains('commit-msg', Util::getHooks());
     }
 
-    /**
-     * Tests Util::findPreviousHead
-     */
     public function testFindPreviousHeadFallback(): void
     {
         $io = $this->createIOMock();
@@ -126,9 +95,7 @@ class UtilTest extends TestCase
 
         $this->assertEquals('HEAD@{1}', $prev);
     }
-    /**
-     * Tests Util::findPreviousHead
-     */
+
     public function testFindPreviousHeadFromStdIn(): void
     {
         $io = $this->createIOMock();

--- a/tests/unit/HooksTest.php
+++ b/tests/unit/HooksTest.php
@@ -16,26 +16,17 @@ use PHPUnit\Framework\TestCase;
 
 class HooksTest extends TestCase
 {
-    /**
-     * Tests Hooks::getOriginalHookArguments
-     */
     public function testHookArguments(): void
     {
         $this->assertEquals('', Hooks::getOriginalHookArguments('pre-commit'));
         $this->assertEquals(' {$PREVIOUSHEAD} {$NEWHEAD} {$MODE}', Hooks::getOriginalHookArguments('post-checkout'));
     }
 
-    /**
-     * Tests Hooks::getVirtualHook
-     */
     public function testGetVirtualHook(): void
     {
         $this->assertEquals('post-change', Hooks::getVirtualHook('post-rewrite'));
     }
 
-    /**
-     * Tests Hooks::getNativeHooksForVirtualHook
-     */
     public function testGetNativeHooksForVirtualHookWithVirtual(): void
     {
         $hooks = Hooks::getNativeHooksForVirtualHook(Hooks::POST_CHANGE);
@@ -45,9 +36,6 @@ class HooksTest extends TestCase
         $this->assertTrue(in_array(Hooks::POST_REWRITE, $hooks));
     }
 
-    /**
-     * Tests Hooks::getNativeHooksForVirtualHook
-     */
     public function testGetNativeHooksForVirtualHookWithNative(): void
     {
         $hooks = Hooks::getNativeHooksForVirtualHook(Hooks::PRE_COMMIT);
@@ -55,9 +43,6 @@ class HooksTest extends TestCase
         $this->assertTrue(empty($hooks));
     }
 
-    /**
-     * Tests Hooks::getVirtualHook
-     */
     public function testGetVirtualHookFail(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Plugin/DummyConstrainedHookPlugin.php
+++ b/tests/unit/Plugin/DummyConstrainedHookPlugin.php
@@ -10,7 +10,7 @@ class DummyConstrainedHookPlugin extends DummyHookPlugin implements Constrained
     /**
      * @var Restriction|null
      */
-    public static $restriction;
+    public static ?Restriction $restriction;
 
     public static function getRestriction(): Restriction
     {

--- a/tests/unit/Plugin/DummyConstrainedHookPluginAlt.php
+++ b/tests/unit/Plugin/DummyConstrainedHookPluginAlt.php
@@ -10,7 +10,7 @@ class DummyConstrainedHookPluginAlt extends DummyHookPlugin implements Constrain
     /**
      * @var Restriction|null
      */
-    public static $restriction;
+    public static ?Restriction $restriction;
 
     public static function getRestriction(): Restriction
     {

--- a/tests/unit/Plugin/DummyConstrainedPlugin.php
+++ b/tests/unit/Plugin/DummyConstrainedPlugin.php
@@ -10,7 +10,7 @@ class DummyConstrainedPlugin extends DummyPlugin implements Constrained
     /**
      * @var Restriction|null
      */
-    public static $restriction;
+    public static ?Restriction $restriction;
 
     public static function getRestriction(): Restriction
     {

--- a/tests/unit/Plugin/DummyHookPluginSkipsActions.php
+++ b/tests/unit/Plugin/DummyHookPluginSkipsActions.php
@@ -21,7 +21,7 @@ class DummyHookPluginSkipsActions extends DummyHookPlugin
      *
      * @var int
      */
-    public static $skipStartAt = 1;
+    public static int $skipStartAt = 1;
 
     public function beforeHook(RunnerHook $hook): void
     {

--- a/tests/unit/Plugin/Hook/PreserveWorkingTreeTest.php
+++ b/tests/unit/Plugin/Hook/PreserveWorkingTreeTest.php
@@ -201,12 +201,12 @@ class PreserveWorkingTreeTest extends TestCase
         $this->statusOperator
             ->expects($this->once())
             ->method('restoreWorkingTree')
-            ->will($this->returnCallback(function (): bool {
+            ->willReturnCallback(function (): bool {
                 if (getenv(PreserveWorkingTree::SKIP_POST_CHECKOUT_VAR) != '1') {
                     $this->fail(PreserveWorkingTree::SKIP_POST_CHECKOUT_VAR . ' did not have the correct value');
                 }
                 return true;
-            }));
+            });
 
         $this->diffOperator
             ->expects($this->once())

--- a/tests/unit/Runner/Action/Cli/Command/FormatterTest.php
+++ b/tests/unit/Runner/Action/Cli/Command/FormatterTest.php
@@ -22,9 +22,6 @@ class FormatterTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests Formatter::format
-     */
     public function testFormatArgumentPlaceholders(): void
     {
         $config = $this->createConfigMock();
@@ -38,9 +35,6 @@ class FormatterTest extends TestCase
         $this->assertEquals('cmd argument bar', $command);
     }
 
-    /**
-     * Tests Formatter::format
-     */
     public function testFormatInvalidPlaceholderReplacedWithEmptyString(): void
     {
         $config = $this->createConfigMock();
@@ -54,9 +48,6 @@ class FormatterTest extends TestCase
         $this->assertEquals('cmd argument ', $command);
     }
 
-    /**
-     * Tests Formatter::format
-     */
     public function testCachedPlaceholder(): void
     {
         $io     = $this->createIOMock();
@@ -77,10 +68,6 @@ class FormatterTest extends TestCase
         $this->assertEquals('cmd3 argument foo/file1.php bar/file2.php baz/file3.php', $command3);
     }
 
-
-    /**
-     * Tests Formatter::format
-     */
     public function testComplexPlaceholder(): void
     {
         $io     = $this->createIOMock();

--- a/tests/unit/Runner/Action/Cli/Command/Placeholder/ArgTest.php
+++ b/tests/unit/Runner/Action/Cli/Command/Placeholder/ArgTest.php
@@ -22,9 +22,6 @@ class ArgTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests Arg::replacement
-     */
     public function testArgValue(): void
     {
         $expected = '.git/EDIT.msg';
@@ -40,9 +37,6 @@ class ArgTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /**
-     * Tests Arg::replacement
-     */
     public function testNoValueOf(): void
     {
         $io     = $this->createIOMock();
@@ -56,9 +50,6 @@ class ArgTest extends TestCase
         $this->assertEquals('', $result);
     }
 
-    /**
-     * Tests Arg::replacement
-     */
     public function testDefault(): void
     {
         $io     = $this->createIOMock();

--- a/tests/unit/Runner/Action/Cli/Command/Placeholder/BranchFilesTest.php
+++ b/tests/unit/Runner/Action/Cli/Command/Placeholder/BranchFilesTest.php
@@ -30,9 +30,6 @@ class BranchFilesTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests BranchFiles::replacement
-     */
     public function testFindStarByReflogWithCustomSeparator(): void
     {
         $io     = $this->createIOMock();
@@ -59,9 +56,6 @@ class BranchFilesTest extends TestCase
         $this->assertEquals('file1.php,file2.php,README.md', $replaced);
     }
 
-    /**
-     * Tests BranchFiles::replacement
-     */
     public function testCantFindStartByReflog(): void
     {
         $io     = $this->createIOMock();
@@ -86,9 +80,6 @@ class BranchFilesTest extends TestCase
         $this->assertEquals('', $replaced);
     }
 
-    /**
-     * Tests BranchFiles::replacement
-     */
     public function testCompareToOfType(): void
     {
         $io     = $this->createIOMock();
@@ -110,9 +101,6 @@ class BranchFilesTest extends TestCase
         $this->assertEquals('file1.php file2.php', $replaced);
     }
 
-    /**
-     * Tests BranchFiles::replacement
-     */
     public function testFilterByDirectory(): void
     {
         $io     = $this->createIOMock();
@@ -134,9 +122,6 @@ class BranchFilesTest extends TestCase
         $this->assertEquals('foo/file1.php foo/file2.php', $replaced);
     }
 
-    /**
-     * Tests BranchFiles::replacement
-     */
     public function testReplaceWith(): void
     {
         $io     = $this->createIOMock();

--- a/tests/unit/Runner/Action/Cli/Command/Placeholder/ChangedFilesTest.php
+++ b/tests/unit/Runner/Action/Cli/Command/Placeholder/ChangedFilesTest.php
@@ -30,9 +30,6 @@ class ChangedFilesTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests ChangedFiles::replacement
-     */
     public function testCustomSeparator(): void
     {
         $io     = $this->createIOMock();
@@ -47,9 +44,6 @@ class ChangedFilesTest extends TestCase
         $this->assertEquals('file1.php, file2.php, README.md', $command);
     }
 
-    /**
-     * Tests ChangedFiles::replacement
-     */
     public function testOfType(): void
     {
         $io     = $this->createIOMock();
@@ -64,9 +58,6 @@ class ChangedFilesTest extends TestCase
         $this->assertEquals('file1.php file2.php', $command);
     }
 
-    /**
-     * Tests ChangedFiles::replacement
-     */
     public function testFilterByDirectory(): void
     {
         $io     = $this->createIOMock();
@@ -81,9 +72,6 @@ class ChangedFilesTest extends TestCase
         $this->assertEquals('foo/file1.php foo/file2.php', $command);
     }
 
-    /**
-     * Tests ChangedFiles::replacement
-     */
     public function testReplaceWith(): void
     {
         $io     = $this->createIOMock();

--- a/tests/unit/Runner/Action/Cli/Command/Placeholder/ConfigTest.php
+++ b/tests/unit/Runner/Action/Cli/Command/Placeholder/ConfigTest.php
@@ -22,9 +22,6 @@ class ConfigTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests Config::replacement
-     */
     public function testConfigValue(): void
     {
         $io     = $this->createIOMock();
@@ -38,9 +35,6 @@ class ConfigTest extends TestCase
         $this->assertEquals('./.git', $gitDir);
     }
 
-    /**
-     * Tests Config::replacement
-     */
     public function testCustomConfigValue(): void
     {
         $io     = $this->createIOMock();
@@ -54,9 +48,6 @@ class ConfigTest extends TestCase
         $this->assertEquals('bar', $replace);
     }
 
-    /**
-     * Tests Config::replacement
-     */
     public function testCustomConfigValueNotFound(): void
     {
         $io     = $this->createIOMock();
@@ -70,9 +61,6 @@ class ConfigTest extends TestCase
         $this->assertEquals('', $replace);
     }
 
-    /**
-     * Tests Config::replacement
-     */
     public function testNoValueOf(): void
     {
         $io     = $this->createIOMock();
@@ -85,9 +73,6 @@ class ConfigTest extends TestCase
         $this->assertEquals('', $gitDir);
     }
 
-    /**
-     * Tests Config::replacement
-     */
     public function testInvalidConfigValue(): void
     {
         $io     = $this->createIOMock();

--- a/tests/unit/Runner/Action/Cli/Command/Placeholder/EnvTest.php
+++ b/tests/unit/Runner/Action/Cli/Command/Placeholder/EnvTest.php
@@ -22,9 +22,6 @@ class EnvTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests Env::replacement
-     */
     public function testEnvValue(): void
     {
         $_ENV['foo'] = 'bar';
@@ -41,9 +38,6 @@ class EnvTest extends TestCase
         unset($_ENV['foo']);
     }
 
-    /**
-     * Tests Env::replacement
-     */
     public function testNoValueOf(): void
     {
         $io     = $this->createIOMock();
@@ -56,9 +50,6 @@ class EnvTest extends TestCase
         $this->assertEquals('', $result);
     }
 
-    /**
-     * Tests Env::replacement
-     */
     public function testDefault(): void
     {
         $io     = $this->createIOMock();

--- a/tests/unit/Runner/Action/Cli/Command/Placeholder/StagedFilesTest.php
+++ b/tests/unit/Runner/Action/Cli/Command/Placeholder/StagedFilesTest.php
@@ -22,9 +22,6 @@ class StagedFilesTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests StagedFiles::replacement
-     */
     public function testCustomSeparator(): void
     {
         $io     = $this->createIOMock();
@@ -39,9 +36,6 @@ class StagedFilesTest extends TestCase
         $this->assertEquals('file1.php, file2.php, README.md', $command);
     }
 
-    /**
-     * Tests StagedFiles::replacement
-     */
     public function testCustomDiffFilter(): void
     {
         $io     = $this->createIOMock();
@@ -56,9 +50,6 @@ class StagedFilesTest extends TestCase
         $this->assertEquals('file1.php file2.php README.md', $command);
     }
 
-    /**
-     * Tests StagedFiles::replacement
-     */
     public function testOfType(): void
     {
         $io     = $this->createIOMock();
@@ -74,9 +65,6 @@ class StagedFilesTest extends TestCase
         $this->assertEquals('file1.php file2.php', $command);
     }
 
-    /**
-     * Tests StagedFiles::replacement
-     */
     public function testFilterByDirectory(): void
     {
         $io     = $this->createIOMock();
@@ -91,9 +79,6 @@ class StagedFilesTest extends TestCase
         $this->assertEquals('foo/file1.php foo/file2.php', $command);
     }
 
-    /**
-     * Tests StagedFiles::replacement
-     */
     public function testReplaceWith(): void
     {
         $io     = $this->createIOMock();

--- a/tests/unit/Runner/Action/Cli/Command/Placeholder/StdInTest.php
+++ b/tests/unit/Runner/Action/Cli/Command/Placeholder/StdInTest.php
@@ -22,9 +22,6 @@ class StdInTest extends TestCase
     use AppMockery;
     use ConfigMockery;
 
-    /**
-     * Tests StdIn::replacement
-     */
     public function testStdInValue(): void
     {
         $expected = 'refs/heads/main 9dfa0fa6221d75f48b2dfac359127324bedf8409'
@@ -41,9 +38,6 @@ class StdInTest extends TestCase
         $this->assertEquals(escapeshellarg($expected), $result);
     }
 
-    /**
-     * Tests StdIn::replacement
-     */
     public function testEmptyStdIn(): void
     {
         $io     = $this->createIOMock();

--- a/tests/unit/Runner/Action/CliTest.php
+++ b/tests/unit/Runner/Action/CliTest.php
@@ -23,11 +23,6 @@ class CliTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests Cli::execute
-     *
-     * @throws \CaptainHook\App\Exception\ActionFailed
-     */
     public function testExecuteSuccess(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -49,11 +44,6 @@ class CliTest extends TestCase
         $cli->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests Cli::execute
-     *
-     * @throws \CaptainHook\App\Exception\ActionFailed
-     */
     public function testExecuteSuccessWithReplacements(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -74,11 +64,6 @@ class CliTest extends TestCase
         $cli->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests Cli::execute
-     *
-     * @throws \CaptainHook\App\Exception\ActionFailed
-     */
     public function testExecuteFailure(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Runner/Action/DummyNoAction.php
+++ b/tests/unit/Runner/Action/DummyNoAction.php
@@ -13,9 +13,6 @@ namespace CaptainHook\App\Runner\Action;
 
 class DummyNoAction
 {
-    /**
-     * Barish
-     */
     public function dummy()
     {
         // do something barish

--- a/tests/unit/Runner/Action/DummyPHPConstraint.php
+++ b/tests/unit/Runner/Action/DummyPHPConstraint.php
@@ -23,7 +23,7 @@ class DummyPHPConstraint implements ActionInterface, ConstrainInterface
     /**
      * Execute static action without errors or exceptions
      */
-    public static function executeStatic()
+    public static function executeStatic(): void
     {
         // do something fooish statically
     }

--- a/tests/unit/Runner/Action/PHPTest.php
+++ b/tests/unit/Runner/Action/PHPTest.php
@@ -24,9 +24,6 @@ class PHPTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests PHP::execute
-     */
     public function testExecuteSuccess(): void
     {
         $config = $this->createConfigMock();
@@ -42,9 +39,6 @@ class PHPTest extends TestCase
         $php->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests PHP::execute
-     */
     public function testExecuteEventSubscriber(): void
     {
         $config = $this->createConfigMock();
@@ -60,9 +54,6 @@ class PHPTest extends TestCase
         $php->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests PHP::execute
-     */
     public function testExecuteConstraintApplicable(): void
     {
         $config = $this->createConfigMock();
@@ -78,9 +69,6 @@ class PHPTest extends TestCase
         $php->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests PHP::execute
-     */
     public function testExecuteConstraintNotApplicable(): void
     {
         $config = $this->createConfigMock();
@@ -96,11 +84,6 @@ class PHPTest extends TestCase
         $php->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests PHP::execute
-     *
-     * @throws \CaptainHook\App\Exception\ActionFailed
-     */
     public function testExecuteFailure(): void
     {
         $this->expectException(Exception::class);
@@ -118,11 +101,6 @@ class PHPTest extends TestCase
         $php->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests PHP::execute
-     *
-     * @throws \CaptainHook\App\Exception\ActionFailed
-     */
     public function testExecuteError(): void
     {
         $this->expectException(Exception::class);
@@ -140,11 +118,6 @@ class PHPTest extends TestCase
         $php->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests PHP::execute
-     *
-     * @throws \CaptainHook\App\Exception\ActionFailed
-     */
     public function testExecuteNoAction(): void
     {
         $this->expectException(Exception::class);
@@ -162,11 +135,6 @@ class PHPTest extends TestCase
         $php->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests PHP::executeStatic
-     *
-     * @throws \CaptainHook\App\Exception\ActionFailed
-     */
     public function testExecuteStaticClassNotFound(): void
     {
         $this->expectException(Exception::class);
@@ -185,11 +153,6 @@ class PHPTest extends TestCase
         $php->execute($config, $io, $repo, $action);
     }
 
-    /**
-     * Tests PHP::executeStatic
-     *
-     * @throws \CaptainHook\App\Exception\ActionFailed
-     */
     public function testExecuteStaticMethodNotFound(): void
     {
         $this->expectException(Exception::class);
@@ -208,12 +171,6 @@ class PHPTest extends TestCase
         $php->execute($config, $io, $repo, $action);
     }
 
-
-    /**
-     * Tests PHP::executeStatic
-     *
-     * @throws \CaptainHook\App\Exception\ActionFailed
-     */
     public function testExecuteStaticSuccess(): void
     {
         $config = $this->createConfigMock();

--- a/tests/unit/Runner/ConditionTest.php
+++ b/tests/unit/Runner/ConditionTest.php
@@ -27,9 +27,6 @@ class ConditionTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests Condition::doesConditionApply
-     */
     public function testPHPConditionApply(): void
     {
         $config = $this->createConfigMock();
@@ -52,9 +49,6 @@ class ConditionTest extends TestCase
         $this->assertTrue($runner->doesConditionApply($conditionConfig));
     }
 
-    /**
-     * Tests Condition::doesConditionApply
-     */
     public function testConditionNotExecutedDueToConstraint(): void
     {
         $config = $this->createConfigMock();
@@ -74,9 +68,6 @@ class ConditionTest extends TestCase
         $this->assertTrue($runner->doesConditionApply($conditionConfig));
     }
 
-    /**
-     * Test Condition::doesConditionApply
-     */
     public function testClassNotFound(): void
     {
         $this->expectException(Exception::class);
@@ -92,9 +83,6 @@ class ConditionTest extends TestCase
         $runner->doesConditionApply($conditionConfig);
     }
 
-    /**
-     * Test Condition::doesConditionApply
-     */
     public function testConfigDependantCondition(): void
     {
         $config = $this->createConfigMock();
@@ -111,9 +99,6 @@ class ConditionTest extends TestCase
         $this->assertTrue($runner->doesConditionApply($conditionConfig));
     }
 
-    /**
-     * Test Condition::doesConditionApply
-     */
     public function testDoesConditionApplyCli(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -129,9 +114,6 @@ class ConditionTest extends TestCase
         $this->assertTrue($runner->doesConditionApply($conditionConfig));
     }
 
-    /**
-     * Test Condition::doesConditionApply
-     */
     public function testAndConditionIsCorrectlyInterpreted(): void
     {
         $io = $this->createIOMock();
@@ -160,9 +142,6 @@ class ConditionTest extends TestCase
         $this->assertTrue($runner->doesConditionApply($conditionConfig));
     }
 
-    /**
-     * Test Condition::doesConditionApply
-     */
     public function testOrConditionIsCorrectlyInterpreted(): void
     {
         $io = $this->createIOMock();

--- a/tests/unit/Runner/Config/EditorTest.php
+++ b/tests/unit/Runner/Config/EditorTest.php
@@ -24,11 +24,6 @@ class EditorTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests Editor::run
-     *
-     * @throws \Exception
-     */
     public function testInvalidHook(): void
     {
         $this->expectException(Exception::class);
@@ -42,9 +37,6 @@ class EditorTest extends TestCase
                ->run();
     }
 
-    /**
-     * Tests Editor::run
-     */
     public function testNoHook(): void
     {
         $this->expectException(Exception::class);
@@ -58,11 +50,6 @@ class EditorTest extends TestCase
                ->run();
     }
 
-    /**
-     * Tests Editor::run
-     *
-     * @throws \Exception
-     */
     public function testNoChange(): void
     {
         $this->expectException(Exception::class);
@@ -76,11 +63,6 @@ class EditorTest extends TestCase
                ->run();
     }
 
-    /**
-     * Tests Editor::run
-     *
-     * @throws \Exception
-     */
     public function testInvalidChange(): void
     {
         $this->expectException(Exception::class);
@@ -95,11 +77,6 @@ class EditorTest extends TestCase
                ->run();
     }
 
-    /**
-     * Tests Editor::run
-     *
-     * @throws \Exception
-     */
     public function testMissingHook(): void
     {
         $this->expectException(Exception::class);
@@ -113,11 +90,6 @@ class EditorTest extends TestCase
                ->run();
     }
 
-    /**
-     * Tests Editor::run
-     *
-     * @throws \Exception
-     */
     public function testMissingChange(): void
     {
         $this->expectException(Exception::class);
@@ -131,11 +103,6 @@ class EditorTest extends TestCase
                ->run();
     }
 
-    /**
-     * Tests Editor::run
-     *
-     * @throws \Exception
-     */
     public function testNoConfiguration()
     {
         $this->expectException(Exception::class);
@@ -150,21 +117,19 @@ class EditorTest extends TestCase
                ->run();
     }
 
-    /**
-     * Tests Editor::run
-     */
     public function testConfigureFileExtend()
     {
-        $configDir = vfsStream::setup('root', null, ['captainhook.json' => '{}']);
-
-        $io     = $this->createIOMock();
-        $config = $this->createConfigMock(true, $configDir->url() . '/captainhook.json');
+        $configDir   = vfsStream::setup('root', null, ['captainhook.json' => '{}']);
+        $invocations = $this->atLeast(3);
+        $io          = $this->createIOMock();
+        $config      = $this->createConfigMock(true, $configDir->url() . '/captainhook.json');
         $config->method('getHookConfig')->willReturn($this->createHookConfigMock());
-        $io->method('ask')->will(
-            $this->onConsecutiveCalls(
-                ...['y', 'y', '\\Foo\\Bar', 'y', 'foo:bar', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n']
-            )
-        );
+        $io->expects($invocations)
+           ->method('ask')
+           ->willReturnCallback(function ($parameters) use ($invocations) {
+               $results = ['y', 'y', '\\Foo\\Bar', 'y', 'foo:bar', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n'];
+               return $results[$invocations->numberOfInvocations() - 1] ?? '';
+           });
         $io->expects($this->once())->method('askAndValidate')->willReturn('foo:bar');
 
         $runner = new Creator($io, $config);

--- a/tests/unit/Runner/Config/ReaderTest.php
+++ b/tests/unit/Runner/Config/ReaderTest.php
@@ -25,7 +25,6 @@ class ReaderTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-
     public function testOnlyWorksIfConfigIsLoadedFromFile(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Runner/Config/Setup/AdvancedTest.php
+++ b/tests/unit/Runner/Config/Setup/AdvancedTest.php
@@ -22,41 +22,36 @@ class AdvancedTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests Advanced::configureHooks
-     *
-     * @throws \Exception
-     */
     public function testConfigureCliHook(): void
     {
-        $io     = $this->createIOMock();
-        $config = $this->createConfigMock();
+        $invocations = $this->atLeast(3);
+        $io          = $this->createIOMock();
+        $config      = $this->createConfigMock();
         $config->expects($this->exactly(9))->method('getHookConfig')->willReturn($this->createHookConfigMock());
-        $io->method('ask')->will(
-            $this->onConsecutiveCalls(
-                ...['y', 'y', 'echo \'foo\'', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n']
-            )
-        );
+        $io->expects($invocations)
+           ->method('ask')
+           ->willReturnCallback(function ($parameters) use ($invocations) {
+               $results = ['y', 'y', 'echo \'foo\'', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n'];
+               return $results[$invocations->numberOfInvocations() - 1] ?? '';
+           });
 
         $setup  = new Advanced($io);
         $setup->configureHooks($config);
     }
 
-    /**
-     * Tests Advanced::configureHooks
-     *
-     * @throws \Exception
-     */
     public function testConfigurePHPHook(): void
     {
-        $io     = $this->createIOMock();
-        $config = $this->createConfigMock();
+        $invocations = $this->atLeast(3);
+        $io          = $this->createIOMock();
+        $config      = $this->createConfigMock();
         $config->method('getHookConfig')->willReturn($this->createHookConfigMock());
-        $io->method('ask')->will(
-            $this->onConsecutiveCalls(
-                ...['y', 'y', '\\Foo\\Bar', 'y', 'foo:bar', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n']
-            )
-        );
+        $io->expects($invocations)
+           ->method('ask')
+           ->willReturnCallback(function ($parameters) use ($invocations) {
+               $results = ['y', 'y', '\\Foo\\Bar', 'y', 'foo:bar', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n', 'n'];
+               return $results[$invocations->numberOfInvocations() - 1] ?? '';
+           });
+
         $io->expects($this->once())->method('askAndValidate')->willReturn('foo:bar');
 
         $setup  = new Advanced($io);

--- a/tests/unit/Runner/Config/Setup/ExpressTest.php
+++ b/tests/unit/Runner/Config/Setup/ExpressTest.php
@@ -22,17 +22,18 @@ class ExpressTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests Express::configureHooks
-     *
-     * @throws \Exception
-     */
     public function testConfigureExpress(): void
     {
-        $io     = $this->createIOMock();
-        $config = $this->createConfigMock();
+        $invokedCount = $this->atLeast(6);
+        $io           = $this->createIOMock();
+        $config       = $this->createConfigMock();
         $config->expects($this->exactly(2))->method('getHookConfig')->willReturn($this->createHookConfigMock());
-        $io->method('ask')->will($this->onConsecutiveCalls('y', 'y', 'y', 'phpunit', 'y', 'phpcs'));
+        $io->expects($invokedCount)
+           ->method('ask')
+           ->willReturnCallback(function ($parameters) use ($invokedCount) {
+               $results = ['y', 'y', 'y', 'phpunit', 'y', 'phpcs'];
+               return $results[$invokedCount->numberOfInvocations() - 1] ?? '';
+           });
 
         $setup  = new Express($io);
         $setup->configureHooks($config);

--- a/tests/unit/Runner/Config/Setup/GuidedTest.php
+++ b/tests/unit/Runner/Config/Setup/GuidedTest.php
@@ -16,21 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class GuidedTest extends TestCase
 {
-    /**
-     * Tests Guided::isPHPActionOptionValid
-     *
-     * @throws \Exception
-     */
     public function testPHPActionOptionValidationValid(): void
     {
         $this->assertEquals('foo:bar', Guided::isPHPActionOptionValid('foo:bar'));
     }
 
-    /**
-     * Tests Guided::isPHPActionOptionValid
-     *
-     * @throws \Exception
-     */
     public function testPHPActionOptionValidationInvalid(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Runner/Hook/CommitMsgTest.php
+++ b/tests/unit/Runner/Hook/CommitMsgTest.php
@@ -34,9 +34,6 @@ class CommitMsgTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests CommitMsg::run
-     */
     public function testRunHookEnabled(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -66,9 +63,6 @@ class CommitMsgTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests CommitMsg::run
-     */
     public function testRunHookSkippedBecauseOfFixup(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -100,11 +94,6 @@ class CommitMsgTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests CommitMsg::run
-     *
-     * @throws \Exception
-     */
     public function testRunWithoutCommitMsgFile(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Runner/Hook/LogTest.php
+++ b/tests/unit/Runner/Hook/LogTest.php
@@ -18,7 +18,6 @@ use PHPUnit\Framework\TestCase;
 
 class LogTest extends TestCase
 {
-    # @Test
     public function testHasMessageForVerbosityEmptyLog(): void
     {
         $log = new Log();
@@ -30,7 +29,6 @@ class LogTest extends TestCase
         $this->assertFalse($log->hasMessageForVerbosity(IO::NORMAL));
     }
 
-    # @Test
     public function testHasMessageForVerbositySingleLog(): void
     {
         $log = new Log();
@@ -48,7 +46,6 @@ class LogTest extends TestCase
         $this->assertFalse($log->hasMessageForVerbosity(IO::NORMAL), 'should not have message for normal');
     }
 
-    # @Test
     public function testHasMessageForVerbosityMultiLog(): void
     {
         $log = new Log();

--- a/tests/unit/Runner/Hook/PostCheckoutTest.php
+++ b/tests/unit/Runner/Hook/PostCheckoutTest.php
@@ -23,11 +23,6 @@ class PostCheckoutTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests PostCheckout::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookEnabled(): void
     {
         $io     = $this->createIOMock();
@@ -56,11 +51,6 @@ class PostCheckoutTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests PostCheckout::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookDisabled(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Runner/Hook/PostCommitTest.php
+++ b/tests/unit/Runner/Hook/PostCommitTest.php
@@ -23,11 +23,6 @@ class PostCommitTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookEnabled(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -53,11 +48,6 @@ class PostCommitTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookDisabled(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Runner/Hook/PostMergeTest.php
+++ b/tests/unit/Runner/Hook/PostMergeTest.php
@@ -24,11 +24,6 @@ class PostMergeTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests PostMerge::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookEnabled(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -52,11 +47,6 @@ class PostMergeTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests PostMerge::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookWithConditionsApply(): void
     {
         $dummy = new DummyRepo(['hooks' => ['post-merge' => '# hook script']]);
@@ -79,12 +69,6 @@ class PostMergeTest extends TestCase
         $runner->run();
     }
 
-
-    /**
-     * Tests PostMerge::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookWithConditionsFail()
     {
         $dummy = new DummyRepo(['hooks' => ['post-merge' => '# hook script']]);
@@ -107,11 +91,6 @@ class PostMergeTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests PostMerge::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookDisabled()
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Runner/Hook/PostRewriteTest.php
+++ b/tests/unit/Runner/Hook/PostRewriteTest.php
@@ -23,11 +23,6 @@ class PostRewriteTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests PrePush::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookEnabled(): void
     {
         $dummy = new DummyRepo(['hooks' => ['post-rewrite' => '# hook script']]);

--- a/tests/unit/Runner/Hook/PreCommitTest.php
+++ b/tests/unit/Runner/Hook/PreCommitTest.php
@@ -25,11 +25,6 @@ class PreCommitTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookEnabled(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -58,11 +53,6 @@ class PreCommitTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookDontFailOnFirstError(): void
     {
         $this->expectException(ActionFailed::class);
@@ -106,9 +96,6 @@ class PreCommitTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests PreCommit::run
-     */
     public function testRunHookDontFailEvenOnExceptions(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -146,12 +133,6 @@ class PreCommitTest extends TestCase
         $runner->run();
     }
 
-
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookAllowFailureGlobally(): void
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
@@ -190,11 +171,6 @@ class PreCommitTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests PreCommit::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookDisabled(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Runner/Hook/PrePushTest.php
+++ b/tests/unit/Runner/Hook/PrePushTest.php
@@ -23,11 +23,6 @@ class PrePushTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests PrePush::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookEnabled(): void
     {
         $dummy = new DummyRepo(['hooks' => ['pre-push' => '# hook script']]);
@@ -48,11 +43,6 @@ class PrePushTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests PrePush::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookEnabledNoActions(): void
     {
         $dummy = new DummyRepo(['hooks' => ['pre-push' => '# hook script']]);
@@ -72,11 +62,6 @@ class PrePushTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests PrePush::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookDisabled(): void
     {
         $io           = $this->createIOMock();

--- a/tests/unit/Runner/Hook/PrepareCommitMsgTest.php
+++ b/tests/unit/Runner/Hook/PrepareCommitMsgTest.php
@@ -27,11 +27,6 @@ class PrepareCommitMsgTest extends TestCase
     use IOMockery;
     use CHMockery;
 
-    /**
-     * Tests PrepareCommitMsg::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookEnabled(): void
     {
         $io           = $this->createIOMock();
@@ -66,11 +61,6 @@ class PrepareCommitMsgTest extends TestCase
         $this->assertEquals('Prepared commit msg', file_get_contents($commitMessageFile));
     }
 
-    /**
-     * Tests PrepareCommitMsg::run
-     *
-     * @throws \Exception
-     */
     public function testRunHookNoMessageException(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Runner/Hook/PrinterTest.php
+++ b/tests/unit/Runner/Hook/PrinterTest.php
@@ -24,7 +24,6 @@ class PrinterTest extends TestCase
     use AppMockery;
     use IOMockery;
 
-    # @Test
     public function testHookEndDebug(): void
     {
         $io = $this->createIOMock();
@@ -44,7 +43,6 @@ class PrinterTest extends TestCase
         $printer->hookEnded(HookRunner::HOOK_SUCCEEDED, $log, 0.25);
     }
 
-    # @Test
     public function testHookEndVeryVerbose(): void
     {
         $io = $this->createIOMock();
@@ -65,7 +63,6 @@ class PrinterTest extends TestCase
         $printer->hookEnded(HookRunner::HOOK_SUCCEEDED, $log, 0.25);
     }
 
-    # @Test
     public function testHookEndVerbose(): void
     {
         $io = $this->createIOMock();

--- a/tests/unit/Runner/InstallerTest.php
+++ b/tests/unit/Runner/InstallerTest.php
@@ -32,11 +32,6 @@ class InstallerTest extends TestCase
     use CHMockery;
     use HookMockery;
 
-    /**
-     * Tests Installer::setHook
-     *
-     * @throws \CaptainHook\App\Exception\InvalidHookName
-     */
     public function testSetInvalidHook(): void
     {
         $this->expectException(InvalidHookName::class);
@@ -50,11 +45,6 @@ class InstallerTest extends TestCase
         $runner->setHook('itDoNotExist');
     }
 
-    /**
-     * Tests Installer::setHook
-     *
-     * @throws \CaptainHook\App\Exception\InvalidHookName
-     */
     public function testSetMultipleInvalidHooks(): void
     {
         $this->expectException(InvalidHookName::class);
@@ -68,11 +58,6 @@ class InstallerTest extends TestCase
         $runner->setHook('itDoNotExist1,itDoNotExist2,itDontExist3');
     }
 
-    /**
-     * Tests Installer::setHook
-     *
-     * @throws \CaptainHook\App\Exception\InvalidHookName
-     */
     public function testSetHookAndEnabledOnly(): void
     {
         $this->expectException(Exception::class);
@@ -87,11 +72,6 @@ class InstallerTest extends TestCase
         $runner->setHook('pre-push');
     }
 
-    /**
-     * Tests Installer::setHook
-     *
-     * @throws \CaptainHook\App\Exception\InvalidHookName
-     */
     public function testMoveAfterSkippingFail(): void
     {
         $this->expectException(RuntimeException::class);
@@ -107,11 +87,6 @@ class InstallerTest extends TestCase
         $runner->setMoveExistingTo('/tmp/');
     }
 
-    /**
-     * Tests Installer::setHook
-     *
-     * @throws \CaptainHook\App\Exception\InvalidHookName
-     */
     public function testSkipAfterMovingFail(): void
     {
         $this->expectException(RuntimeException::class);
@@ -127,9 +102,6 @@ class InstallerTest extends TestCase
         $runner->setSkipExisting(true);
     }
 
-    /**
-     * Tests Installer::run
-     */
     public function testHookInstallationDeclined(): void
     {
         $fakeRepo = new DummyRepo();
@@ -149,9 +121,6 @@ class InstallerTest extends TestCase
         $this->assertFileDoesNotExist($fakeRepo->getHookDir() . '/pre-push');
     }
 
-    /**
-     * Tests Installer::run
-     */
     public function testWriteHook(): void
     {
         $fakeRepo = new DummyRepo();
@@ -191,9 +160,6 @@ class InstallerTest extends TestCase
         $this->assertFileDoesNotExist($fakeRepo->getHookDir() . '/pre-commit');
     }
 
-    /**
-     * Tests Installer::checkForBrokenSymlinks
-     */
     public function testBrokenSymlinkDetectionOnExistingFile(): void
     {
         $io       = $this->createIOMock();
@@ -213,9 +179,6 @@ class InstallerTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * Tests Installer::checkForBrokenSymlinks
-     */
     public function testBrokenSymlinkDetectionOnBrokenAbsoluteSymlink(): void
     {
         $this->expectException(Exception::class);
@@ -236,9 +199,6 @@ class InstallerTest extends TestCase
         $runner->checkSymlink($file);
     }
 
-    /**
-     * Tests Installer::checkForBrokenSymlinks
-     */
     public function testBrokenSymlinkDetectionOnBrokenRelativeSymlink(): void
     {
         $this->expectException(Exception::class);
@@ -259,9 +219,6 @@ class InstallerTest extends TestCase
         $runner->checkSymlink($file);
     }
 
-    /**
-     * Tests Installer::run
-     */
     public function testWriteMultipleHooks(): void
     {
         $fakeRepo = new DummyRepo();
@@ -280,9 +237,6 @@ class InstallerTest extends TestCase
         $this->assertFileExists($fakeRepo->getHookDir() . '/post-checkout');
     }
 
-    /**
-     * Tests Installer::run
-     */
     public function testMoveExistingHook(): void
     {
         $fakeRepo = new DummyRepo(
@@ -319,9 +273,6 @@ class InstallerTest extends TestCase
         $this->assertFileExists($fakeRepo->getRoot() . '/foo/bar/pre-commit');
     }
 
-    /**
-     * Tests Installer::run
-     */
     public function testMoveNotExistingHook(): void
     {
         $fakeRepo = new DummyRepo(
@@ -356,9 +307,6 @@ class InstallerTest extends TestCase
         $this->assertFileExists($fakeRepo->getHookDir() . '/pre-commit');
     }
 
-    /**
-     * Tests Installer::run
-     */
     public function testMoveExistingHookTargetIsFile(): void
     {
         $this->expectException(RuntimeException::class);
@@ -389,9 +337,6 @@ class InstallerTest extends TestCase
                ->run();
     }
 
-    /**
-     * Tests Installer::writeHookFile
-     */
     public function testSkipExisting(): void
     {
         $io       = $this->createIOMock();
@@ -408,9 +353,6 @@ class InstallerTest extends TestCase
         $runner->run();
     }
 
-    /**
-     * Tests Installer::writeHookFile
-     */
     public function testOnlyEnabledAndHooksToHandle(): void
     {
         $this->expectException(Exception::class);
@@ -425,9 +367,6 @@ class InstallerTest extends TestCase
         $runner->setOnlyEnabled(true);
     }
 
-    /**
-     * Tests Installer::writeHookFile
-     */
     public function testDeclineOverwrite(): void
     {
         $io       = $this->createIOMock();

--- a/tests/unit/Runner/UninstallerTest.php
+++ b/tests/unit/Runner/UninstallerTest.php
@@ -30,11 +30,6 @@ class UninstallerTest extends TestCase
     use CHMockery;
     use HookMockery;
 
-    /**
-     * Tests Uninstaller::setHook
-     *
-     * @throws \CaptainHook\App\Exception\InvalidHookName
-     */
     public function testSetInvalidHook(): void
     {
         $this->expectException(InvalidHookName::class);
@@ -47,11 +42,6 @@ class UninstallerTest extends TestCase
         $runner->setHook('itDoesNotExist');
     }
 
-    /**
-     * Tests Uninstaller::setHook
-     *
-     * @throws \CaptainHook\App\Exception\InvalidHookName
-     */
     public function testSetHookAndEnabledOnly(): void
     {
         $this->expectException(Exception::class);
@@ -65,9 +55,6 @@ class UninstallerTest extends TestCase
         $runner->setOnlyDisabled(true);
     }
 
-    /**
-     * Tests Uninstaller::run
-     */
     public function testHookUninstallationDeclined(): void
     {
         $fakeRepo = new DummyRepo([
@@ -92,9 +79,6 @@ class UninstallerTest extends TestCase
         $this->assertFileExists($fakeRepo->getHookDir() . '/pre-push');
     }
 
-    /**
-     * Tests Uninstaller::run
-     */
     public function testForcedHookUninstallation(): void
     {
         $fakeRepo = new DummyRepo([
@@ -119,9 +103,6 @@ class UninstallerTest extends TestCase
         $this->assertFileDoesNotExist($fakeRepo->getHookDir() . '/pre-push');
     }
 
-    /**
-     * Tests Uninstaller::run
-     */
     public function testRemoveHook(): void
     {
         $fakeRepo = new DummyRepo(
@@ -146,9 +127,6 @@ class UninstallerTest extends TestCase
         $this->assertFileExists($fakeRepo->getHookDir() . '/pre-push');
     }
 
-    /**
-     * Tests Uninstaller::run
-     */
     public function testRemoveOnlyDisabled(): void
     {
         $fakeRepo = new DummyRepo(
@@ -180,9 +158,6 @@ class UninstallerTest extends TestCase
         $this->assertFileExists($fakeRepo->getHookDir() . '/pre-push');
     }
 
-    /**
-     * Tests Uninstaller::run
-     */
     public function testMoveExistingHook(): void
     {
         $fakeRepo = new DummyRepo(
@@ -208,9 +183,6 @@ class UninstallerTest extends TestCase
         $this->assertFileExists($fakeRepo->getRoot() . '/foo/bar/post-merge');
     }
 
-    /**
-     * Tests Uninstaller::run
-     */
     public function testMoveExistingHookTargetIsFile(): void
     {
         $this->expectException(RuntimeException::class);
@@ -240,9 +212,6 @@ class UninstallerTest extends TestCase
                ->run();
     }
 
-    /**
-     * Tests Uninstaller::run
-     */
     public function testMoveExistingHookWhenMoveExistingIsAnAbsolutePath(): void
     {
         $virtualFs = vfsStream::setup('root');

--- a/tests/unit/Runner/UtilTest.php
+++ b/tests/unit/Runner/UtilTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class UtilTest extends TestCase
 {
-    /**
-     * Tests Util::getExecType
-     */
     public function testGetTypePHP(): void
     {
         $this->assertEquals('php', Util::getExecType('\\Foo\\Bar'));
@@ -25,9 +22,6 @@ class UtilTest extends TestCase
         $this->assertEquals('php', Util::getExecType('\\Fiz'));
     }
 
-    /**
-     * Tests Util::getExecType
-     */
     public function testGetTypeCli(): void
     {
         $this->assertEquals('cli', Util::getExecType('./my-binary'));
@@ -37,9 +31,6 @@ class UtilTest extends TestCase
         $this->assertEquals('cli', Util::getExecType('/usr/local/bin/phpunit.phar'));
     }
 
-    /**
-     * Tests Util::isTypeValid
-     */
     public function testIsTypeValid(): void
     {
         $this->assertTrue(Util::isTypeValid('php'));
@@ -47,9 +38,6 @@ class UtilTest extends TestCase
         $this->assertFalse(Util::isTypeValid('foo'));
     }
 
-    /**
-     * Tests Util::getEnv
-     */
     public function testCanReadEnvVar(): void
     {
         $_ENV['foo'] = 'bar';
@@ -57,9 +45,6 @@ class UtilTest extends TestCase
         unset($_ENV['foo']);
     }
 
-    /**
-     * Tests Util::getEnv
-     */
     public function testUsesServerSuperglobalAsFallback(): void
     {
         $_SERVER['foo'] = 'bar';
@@ -67,9 +52,6 @@ class UtilTest extends TestCase
         unset($_SERVER['foo']);
     }
 
-    /**
-     * Tests Util::getEnv
-     */
     public function testReturnsDefaultIdEnvNotSet(): void
     {
         $this->assertEquals('baz', Util::getEnv('fiz', 'baz'));

--- a/tests/unit/Storage/File/JsonTest.php
+++ b/tests/unit/Storage/File/JsonTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class JsonTest extends TestCase
 {
-    /**
-     * Tests Json::readAssoc
-     */
     public function testReadInvalid(): void
     {
         $this->expectException(Exception::class);
@@ -28,9 +25,6 @@ class JsonTest extends TestCase
         $json->readAssoc();
     }
 
-    /**
-     * Tests Json::readAssoc
-     */
     public function testReadAssoc(): void
     {
         $path = realpath(CH_PATH_FILES . '/storage/test.json');
@@ -40,9 +34,6 @@ class JsonTest extends TestCase
         $this->assertEquals('bar', $data['foo']);
     }
 
-    /**
-     * Test Json::write
-     */
     public function testWrite(): void
     {
         $path = tempnam(sys_get_temp_dir(), 'json');

--- a/tests/unit/Storage/File/XmlTest.php
+++ b/tests/unit/Storage/File/XmlTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class XmlTest extends TestCase
 {
-    /**
-     * Tests Xml::read
-     */
     public function testRead(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Storage/FileTest.php
+++ b/tests/unit/Storage/FileTest.php
@@ -18,9 +18,6 @@ use RuntimeException;
 
 class FileTest extends TestCase
 {
-    /**
-     * Tests File::getRoot
-     */
     public function testGetPath(): void
     {
         $file = new File(__FILE__);
@@ -28,9 +25,6 @@ class FileTest extends TestCase
         $this->assertEquals(__FILE__, $file->getPath());
     }
 
-    /**
-     * Tests File::read
-     */
     public function testRead(): void
     {
         $file    = new File(__FILE__);
@@ -39,9 +33,6 @@ class FileTest extends TestCase
         $this->assertStringContainsString('<?php', $content);
     }
 
-    /**
-     * Tests File::read
-     */
     public function testReadFail(): void
     {
         $this->expectException(Exception::class);
@@ -50,9 +41,6 @@ class FileTest extends TestCase
         $file->read();
     }
 
-    /**
-     * Tests File::write
-     */
     public function testWrite(): void
     {
         $tmpDir = sys_get_temp_dir();
@@ -64,9 +52,6 @@ class FileTest extends TestCase
         $this->assertTrue(unlink($path));
     }
 
-    /**
-     * Tests File::isLink
-     */
     public function testIsLink(): void
     {
         $tmpDir = sys_get_temp_dir();
@@ -83,9 +68,6 @@ class FileTest extends TestCase
         $this->assertTrue(unlink($target));
     }
 
-    /**
-     * Tests File::linkTarget
-     */
     public function testLinkTarget(): void
     {
         $this->expectException(RuntimeException::class);
@@ -94,9 +76,6 @@ class FileTest extends TestCase
         $file->linkTarget();
     }
 
-    /**
-     * Tests File::write
-     */
     public function testWriteFailNoDir(): void
     {
         $this->expectException(Exception::class);
@@ -106,9 +85,6 @@ class FileTest extends TestCase
         $file->write('foo');
     }
 
-    /**
-     * Tests File::write
-     */
     public function testNoWritePermission(): void
     {
         $this->expectException(Exception::class);
@@ -118,9 +94,6 @@ class FileTest extends TestCase
         $file->write('test');
     }
 
-    /**
-     * Tests File::write
-     */
     public function testCantCreateDirectory(): void
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
This got a log bigger than I anticipated.
 - Switched onConsecutiveCalls to willReturnCallback
 - Switched DataProvider from Annotations to Attributes
 - Made DataProviders static
 - Removed tons of inconsistent PHPDoc
 - Made everything PHPUnit 12 ready
